### PR TITLE
Fix docker file

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -113,9 +113,10 @@ RUN set -ex \
 COPY php-fpm-worker.conf /etc/supervisor/conf.d
 COPY nginx-worker.conf /etc/supervisor/conf.d
 
-ENV NGINX_VERSION 1.12.2-1~jessie
+ENV NGINX_VERSION 1.14.0-1~jessie
 
 RUN echo "deb http://nginx.org/packages/debian/ jessie nginx" >> /etc/apt/sources.list \
+    && curl -O "https://nginx.org/keys/nginx_signing.key" && apt-key add ./nginx_signing.key \
 	&& apt-get update \
 	&& apt-get install --no-install-recommends --no-install-suggests -y --force-yes \
 						ca-certificates \
@@ -135,6 +136,5 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 
 EXPOSE 8097
 
-CMD ["service", "nginx", "start"]
-CMD ["php-fpm"]
+CMD service nginx start && php-fpm
 #CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/supervisord.conf" , "-n"]


### PR DESCRIPTION
Tried to run the project locally and I've run out on some problems:

1. Make sure the corresponding GPG key is inserted into the apt keystore.
2. Update jessie version because the packages **nginx-module-geoip**, **nginx-module-image-filter** and **nginx-module-njs** depend on version 1.14.0-1.
3. There can only be one CMD instruction in a Dockerfile. If more than one CMD is listed, then only the last CMD will take effect. Therefore **nginx** and **php-fpm** services are starting now on the same instruction.