### PR TITLE
Added partnerships page and changed page titles to display translation

### DIFF
--- a/fogospt/app/Http/Controllers/GenericController.php
+++ b/fogospt/app/Http/Controllers/GenericController.php
@@ -30,20 +30,25 @@ class GenericController extends Controller
 
     public function getAbout()
     {
-        $this->setPageName('Sobre');
+        $this->setPageName(__('includes.menu.about'));
         return view('about')->with(['metadata' => $this->generateMetadata()]);
     }
 
     public function getInformation()
     {
-        $this->setPageName('Informação');
+        $this->setPageName(__('includes.menu.information'));
         return view('information')->with(['metadata' => $this->generateMetadata()]);
     }
 
     public function getManifest()
     {
-        $this->setPageName('Manifesto');
+        $this->setPageName(__('includes.menu.manifest'));
         return view('manifest')->with(['metadata' => $this->generateMetadata()]);
+    }
+
+    public function getPartnerships() {
+	    $this->setPageName(__('includes.menu.partnerships'));
+	    return view('partnerships')->with(['metadata' => $this->generateMetadata()]);
     }
 
 	/**

--- a/fogospt/public/css/app.css
+++ b/fogospt/public/css/app.css
@@ -431,6 +431,10 @@ main #data-social-media iframe {
   height: 100vh;
 }
 
+.margin-top-10 {
+  margin-top: 10px;
+}
+
 @-webkit-keyframes loading {
   0%, 100% {
     -webkit-transform: scale(0);

--- a/fogospt/resources/lang/en/includes.php
+++ b/fogospt/resources/lang/en/includes.php
@@ -6,6 +6,7 @@
             'about'       => 'About',
             'information' => 'Informations',
             'manifest'    => 'Manifest',
+            'partnerships' => 'Partnerships',
             'active'      => '(Actual)'
         ],
         'meta' => [

--- a/fogospt/resources/lang/pt/includes.php
+++ b/fogospt/resources/lang/pt/includes.php
@@ -6,6 +6,7 @@
             'about'       => 'Sobre',
             'information' => 'Informações',
             'manifest'    => 'Manifesto',
+            'partnerships' => 'Parcerias',
             'active'      => '(actual)'
         ],
         'meta' => [

--- a/fogospt/resources/views/about.blade.php
+++ b/fogospt/resources/views/about.blade.php
@@ -1,13 +1,15 @@
 @extends('app')
 
 @section('content')
-    <main role="main" class="mb-auto">
-        <div class="modal-body">
-            <p>@lang('pages.about.entries_from')</p>
-            <p>@lang('pages.about.update_interval')</p>
-            <p>@lang('pages.about.near_location')</p>
-            <p>@lang('pages.about.suggestion_bugs')</p>
-            <p>@lang('pages.about.made_by')</p>
-        </div>
-    </main>
+    <div class="container">
+        <main role="main" class="mb-auto margin-top-10">
+            <div class="modal-body">
+                <p>@lang('pages.about.entries_from')</p>
+                <p>@lang('pages.about.update_interval')</p>
+                <p>@lang('pages.about.near_location')</p>
+                <p>@lang('pages.about.suggestion_bugs')</p>
+                <p>@lang('pages.about.made_by')</p>
+            </div>
+        </main>
+    </div>
 @endsection

--- a/fogospt/resources/views/includes/navbar.blade.php
+++ b/fogospt/resources/views/includes/navbar.blade.php
@@ -14,6 +14,7 @@
                 </span></a>
                 <a class="nav-item nav-link" href="{{route('about')}}">@lang('includes.menu.about')</a>
                 <a class="nav-item nav-link" href="{{route('information')}}">@lang('includes.menu.information')</a>
+                <a class="nav-item nav-link" href="{{route('partnerships')}}">@lang('includes.menu.partnerships')</a>
                 <a class="nav-item nav-link" href="{{route('manifest')}}">@lang('includes.menu.manifest')</a>
                 <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown"
                    aria-haspopup="true" aria-expanded="false">

--- a/fogospt/resources/views/information.blade.php
+++ b/fogospt/resources/views/information.blade.php
@@ -1,28 +1,30 @@
 @extends('app')
 
 @section('content')
-    <main role="main" class="mb-auto">
-        <div class="modal-body">
-            <h3>@lang('pages.information.statesOfOccurrences.title')</h3>
-            <ul>
-                <li>@lang('pages.information.statesOfOccurrences.items.firstAlertdispatch')</li>
-                <li>@lang('pages.information.statesOfOccurrences.items.arrivalToOccurrence')</li>
-                <li>@lang('pages.information.statesOfOccurrences.items.ongoing')</li>
-                <li>@lang('pages.information.statesOfOccurrences.items.inResolution')</li>
-                <li>@lang('pages.information.statesOfOccurrences.items.inConclusion')</li>
-                <li>@lang('pages.information.statesOfOccurrences.items.surveillance')</li>
-                <li>@lang('pages.information.statesOfOccurrences.items.closed')</li>
-            </ul>
-            <h3>@lang('pages.information.typeOfUnits.title')</h3>
-            <ul>
-                <li>@lang('pages.information.typeOfUnits.items.humans')
-                </li>
-                <li>@lang('pages.information.typeOfUnits.items.terrestrial')</li>
-                <li>@lang('pages.information.typeOfUnits.items.air')</li>
-            </ul>
-            <p>@lang('pages.information.numberDescription')</p>
-            <p>@lang('pages.information.hoursDescription')</p>
-            <p>@lang('pages.information.source')</p>
-        </div>
-    </main>
+    <div class="container">
+        <main role="main" class="mb-auto margin-top-10">
+            <div class="modal-body">
+                <h3>@lang('pages.information.statesOfOccurrences.title')</h3>
+                <ul>
+                    <li>@lang('pages.information.statesOfOccurrences.items.firstAlertdispatch')</li>
+                    <li>@lang('pages.information.statesOfOccurrences.items.arrivalToOccurrence')</li>
+                    <li>@lang('pages.information.statesOfOccurrences.items.ongoing')</li>
+                    <li>@lang('pages.information.statesOfOccurrences.items.inResolution')</li>
+                    <li>@lang('pages.information.statesOfOccurrences.items.inConclusion')</li>
+                    <li>@lang('pages.information.statesOfOccurrences.items.surveillance')</li>
+                    <li>@lang('pages.information.statesOfOccurrences.items.closed')</li>
+                </ul>
+                <h3>@lang('pages.information.typeOfUnits.title')</h3>
+                <ul>
+                    <li>@lang('pages.information.typeOfUnits.items.humans')
+                    </li>
+                    <li>@lang('pages.information.typeOfUnits.items.terrestrial')</li>
+                    <li>@lang('pages.information.typeOfUnits.items.air')</li>
+                </ul>
+                <p>@lang('pages.information.numberDescription')</p>
+                <p>@lang('pages.information.hoursDescription')</p>
+                <p>@lang('pages.information.source')</p>
+            </div>
+        </main>
+    </div>
 @endsection

--- a/fogospt/resources/views/manifest.blade.php
+++ b/fogospt/resources/views/manifest.blade.php
@@ -1,6 +1,8 @@
 @extends('app')
 @section('content')
-    <main role="main" class="mb-auto">
-        <div>MANIFEST</div>
-    </main>
+    <div class="container">
+        <main role="main" class="mb-auto margin-top-10" >
+            <div>MANIFEST</div>
+        </main>
+    </div>
 @endsection

--- a/fogospt/resources/views/partnerships.blade.php
+++ b/fogospt/resources/views/partnerships.blade.php
@@ -1,0 +1,38 @@
+@extends('app')
+
+@section('content')
+    <div class="container">
+        <main role="main" class="mb-auto margin-top-10">
+            <div class="row">
+                <div class="col-sm">
+                    <div class="card" style="width: 18rem;">
+                        <div class="card-body">
+                            <a href="">
+                                <img src="{{asset('img/firetruck.svg')}}" alt="">
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-sm">
+                    <div class="card" style="width: 18rem;">
+                        <div class="card-body">
+                            <a href="">
+                                <img src="{{asset('img/firetruck.svg')}}" alt="">
+                            </a>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-sm">
+                    <div class="card" style="width: 18rem;">
+                        <div class="card-body">
+                            <a href="">
+                                <img src="{{asset('img/firetruck.svg')}}" alt="">
+                            </a>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </main>
+    </div>
+@endsection

--- a/fogospt/routes/web.php
+++ b/fogospt/routes/web.php
@@ -15,6 +15,7 @@ Route::get('/', 'GenericController@getIndex')->name('home');
 Route::get('/sobre', 'GenericController@getAbout')->name('about');
 Route::get('/informacoes', 'GenericController@getInformation')->name('information');
 Route::get('/manifesto', 'GenericController@getManifest')->name('manifest');
+Route::get('/partnerships', 'GenericController@getPartnerships')->name('partnerships');
 Route::get('/change-language/{lang}', 'GenericController@getChangeLanguage')->name('changeLanguage');
 Route::get('/fogo/{id}', 'FireController@get');
 Route::get('/views/risk/{id}', 'FireController@getGeneralCard');


### PR DESCRIPTION
Added partnerships page/route.
Changed GenericController to set the page title based on user language.
Changed layouts of about, information, manifest to display the content
centered instead align to left, this way page have a better distribution
of white space.

this is a pull request to fill the #4 issue