### PR TITLE
Avoid usage of env() calls to allow caching of config files

### DIFF
--- a/fogospt/routes/web.php
+++ b/fogospt/routes/web.php
@@ -57,6 +57,6 @@ Route::group(['prefix' => 'v1'], function () {
     Route::get('/viirs', 'ApiController@getVIIRS')->name('getVIIRS');
 });
 
-if(ENV('APP_ENV') !== 'production'){
+if (app()->environment() !== 'production') {
     Route::get('/manifesto', 'GenericController@getManifest')->name('manifest');
 }


### PR DESCRIPTION
This PR removes the use of the env() method as these calls will always return null when the configs get cached.