### PR TITLE
Improve Build Docker Images workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,15 +52,15 @@ jobs:
 
     - name: Docker login
       env: 
-        repo-token: ${{ secrets.REPO_TOKEN }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
       run: |
         echo "${repo-token}" | docker login https://docker.pkg.github.com --username tomahock --password-stdin
 
     - name: Push Docker images
       env:
-        repo-token: ${{ secrets.REPO_TOKEN }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        echo "${repo-token}" | docker login https://docker.pkg.github.com --username tomahock --password-stdin
+        echo "${repo-token}" | docker login docker.pkg.github.com -u Moser-ss --password-stdin
         echo "DEBUG: $GITHUB_REF"
         for image in $(docker images --format "{{.Repository}}:{{.Tag}}" |grep fogospt); 
         do 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         docker-buildx bake -f Dockerfile/docker-compose.stage-3.yml
 
 
-    - name: Push t Docker image
+    - name: Publish Docker images
       run: |
         docker login -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}} docker.pkg.github.com
         for image in $(docker images --format "{{.Repository}}:{{.Tag}}" |grep fogospt); 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,14 +50,11 @@ jobs:
         echo "Building storage image"
         docker-buildx bake -f Dockerfile/docker-compose.stage-3.yml
 
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
-      with:
-        name: fogospt/fogospt/composer
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-        registry: docker.pkg.github.com
-        tags: "fogospt-latest"
+
+    - name: Push t Docker image
+      run: |
+        docker login -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}} docker.pkg.github.com
+        docker push docker.pkg.github.com/fogospt/fogospt/storage:fogospt-$GITHUB_SHA
     #- name: Docker login
     #  env: 
     #    repo-token: ${{ secrets.DOCKER_TEST_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,13 +52,13 @@ jobs:
 
     - name: Docker login
       env: 
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.DOCKER_TEST_TOKEN }}
       run: |
-        echo "${repo-token}" | docker login https://docker.pkg.github.com --username tomahock --password-stdin
+        echo "${repo-token}" | docker login docker.pkg.github.com -u Moser-ss --password-stdin
 
     - name: Push Docker images
       env:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        repo-token: ${{ secrets.DOCKER_TEST_TOKEN }}
       run: |
         echo "${repo-token}" | docker login docker.pkg.github.com -u Moser-ss --password-stdin
         echo "DEBUG: $GITHUB_REF"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,10 @@ jobs:
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        name: docker.pkg.github.com/fogospt/fogospt/composer
+        name: fogospt/fogospt/composer
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+        registry: docker.pkg.github.com
         tags: "fogospt-latest"
     #- name: Docker login
     #  env: 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,25 +50,32 @@ jobs:
         echo "Building storage image"
         docker-buildx bake -f Dockerfile/docker-compose.stage-3.yml
 
-    - name: Docker login
-      env: 
-        repo-token: ${{ secrets.DOCKER_TEST_TOKEN }}
-      run: |
-        echo "${repo-token}" | docker login docker.pkg.github.com -u Moser-ss --password-stdin
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: docker.pkg.github.com/fogospt/fogospt/composer
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        tags: "fogospt-latest"
+    #- name: Docker login
+    #  env: 
+    #    repo-token: ${{ secrets.DOCKER_TEST_TOKEN }}
+    #  run: |
+    #    echo "${repo-token}" | docker login docker.pkg.github.com -u Moser-ss --password-stdin
 
-    - name: Push Docker images
-      env:
-        repo-token: ${{ secrets.DOCKER_TEST_TOKEN }}
-      run: |
-        echo "${repo-token}" | docker login docker.pkg.github.com -u Moser-ss --password-stdin
-        echo "DEBUG: $GITHUB_REF"
-        for image in $(docker images --format "{{.Repository}}:{{.Tag}}" |grep fogospt); 
-        do 
-            docker push "$image"
-            if [[ $GITHUB_REF == "master" ]]
-            then
-              latest_image="${image/$GITHUB_SHA/latest}"
-              docker tag "$image" "$latest_image"
-              docker push "$latest_image"
-            fi
-        done;
+    # - name: Push Docker images
+    #   env:
+    #     repo-token: ${{ secrets.DOCKER_TEST_TOKEN }}
+    #   run: |
+    #     echo "${repo-token}" | docker login docker.pkg.github.com -u Moser-ss --password-stdin
+    #     echo "DEBUG: $GITHUB_REF"
+    #     for image in $(docker images --format "{{.Repository}}:{{.Tag}}" |grep fogospt); 
+    #     do 
+    #         docker push "$image"
+    #         if [[ $GITHUB_REF == "master" ]]
+    #         then
+    #           latest_image="${image/$GITHUB_SHA/latest}"
+    #           docker tag "$image" "$latest_image"
+    #           docker push "$latest_image"
+    #         fi
+    #     done;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,11 @@
 name: Build Docker images
 
-on: [push, pull_request]
+on:   
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:  
 
 jobs:
   build-buildx:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,26 +54,13 @@ jobs:
     - name: Push t Docker image
       run: |
         docker login -u $GITHUB_ACTOR -p ${{secrets.GITHUB_TOKEN}} docker.pkg.github.com
-        docker push docker.pkg.github.com/fogospt/fogospt/storage:fogospt-$GITHUB_SHA
-    #- name: Docker login
-    #  env: 
-    #    repo-token: ${{ secrets.DOCKER_TEST_TOKEN }}
-    #  run: |
-    #    echo "${repo-token}" | docker login docker.pkg.github.com -u Moser-ss --password-stdin
-
-    # - name: Push Docker images
-    #   env:
-    #     repo-token: ${{ secrets.DOCKER_TEST_TOKEN }}
-    #   run: |
-    #     echo "${repo-token}" | docker login docker.pkg.github.com -u Moser-ss --password-stdin
-    #     echo "DEBUG: $GITHUB_REF"
-    #     for image in $(docker images --format "{{.Repository}}:{{.Tag}}" |grep fogospt); 
-    #     do 
-    #         docker push "$image"
-    #         if [[ $GITHUB_REF == "master" ]]
-    #         then
-    #           latest_image="${image/$GITHUB_SHA/latest}"
-    #           docker tag "$image" "$latest_image"
-    #           docker push "$latest_image"
-    #         fi
-    #     done;
+        for image in $(docker images --format "{{.Repository}}:{{.Tag}}" |grep fogospt); 
+         do 
+             docker push "$image"
+             if [[ $GITHUB_REF == "*master*" ]]
+             then
+               latest_image="${image/$GITHUB_SHA/latest}"
+               docker tag "$image" "$latest_image"
+               docker push "$latest_image"
+             fi
+         done;


### PR DESCRIPTION
In this PR, the workflow's trigger was improved only to be executed when we push to master branch and when a PR is open to merging to master branch.
The Docker login and docker push steps were merged.
The new step `Publish Docker images` publish all the images built in the workflow that contains `fogospt` in the name. Also if the execution happens in the branch master, it will push the images with tag latest