### PR TITLE
Fix infinite resize on mobile stats view

### DIFF
--- a/fogospt/public/js/stats.js
+++ b/fogospt/public/js/stats.js
@@ -1,730 +1,728 @@
-$(document).ready(function () {
-    const messaging = firebase.messaging();
+$(document).ready(function() {
+  const messaging = firebase.messaging();
 
-    messaging.onMessage(function(payload) {
-        toastr.warning(payload.notification.body);
-    });
+  messaging.onMessage(function(payload) {
+    toastr.warning(payload.notification.body);
+  });
 
+  plot();
+  plotWeekStats();
+  plotStats8hours();
+  plotStats8hoursYesterday();
+  plotStatsYesterdayDistricts();
+  plotStatsLastNight();
+  plotStatsDistricts();
 
-    plot();
-    plotWeekStats();
-    plotStats8hours();
-    plotStats8hoursYesterday();
-    plotStatsYesterdayDistricts();
-    plotStatsLastNight();
-    plotStatsDistricts();
+  plotStatsTotal();
 
-    plotStatsTotal();
+  plotBurnAreaLastDays();
+  plotMotives();
 
-    plotBurnAreaLastDays();
-    plotMotives();
+  if (getParameterByName("phantom")) {
+    $(".phantom-hide").hide();
+  }
 
-    if (getParameterByName('phantom')) {
-        $('.phantom-hide').hide();
-    }
-
-    if (getParameterByName('jn')) {
-        $('#header').hide()
-    }
+  if (getParameterByName("jn")) {
+    $("#header").hide();
+  }
 });
 
 var dColors = {
-    'Aveiro': '#4462a0',
-    'Beja': '#ffa600',
-    'Braga': '#2f4b7c',
-    'Bragança': '#a05195',
-    'Castelo Branco': '#ee598e',
-    'Coimbra': '#d65a9e',
-    'Évora': '#ff932c',
-    'Faro': '#ef9c00',
-    'Guarda': '#b95da9',
-    'Leiria': '#ff5f7a',
-    'Lisboa': '#ff9030',
-    'Portalegre': '#ff7b4b',
-    'Porto': '#005b85',
-    'Santarém': '#ff6a64',
-    'Setúbal': '#ff9f16',
-    'Viana do Castelo': '#003f5c',
-    'Vila Real': '#665191',
-    'Viseu': '#7f62ad',
+  Aveiro: "#4462a0",
+  Beja: "#ffa600",
+  Braga: "#2f4b7c",
+  Bragança: "#a05195",
+  "Castelo Branco": "#ee598e",
+  Coimbra: "#d65a9e",
+  Évora: "#ff932c",
+  Faro: "#ef9c00",
+  Guarda: "#b95da9",
+  Leiria: "#ff5f7a",
+  Lisboa: "#ff9030",
+  Portalegre: "#ff7b4b",
+  Porto: "#005b85",
+  Santarém: "#ff6a64",
+  Setúbal: "#ff9f16",
+  "Viana do Castelo": "#003f5c",
+  "Vila Real": "#665191",
+  Viseu: "#7f62ad",
 };
 
-function plotBurnAreaLastDays(){
-    var url = 'https://api-lb.fogos.pt/v1/stats/burn-area';
-    $.ajax({
-        url: url,
-        method: 'GET',
-        success: function (data) {
-            if (data.success && data.data) {
-                var labels = [];
-                var total = [];
+function plotBurnAreaLastDays() {
+  var url = "https://api-lb.fogos.pt/v1/stats/burn-area";
+  $.ajax({
+    url: url,
+    method: "GET",
+    success: function(data) {
+      if (data.success && data.data) {
+        var labels = [];
+        var total = [];
 
-                for (d in data.data) {
-                    labels.push(d);
-                    total.push(data.data[d]);
-                }
-
-                var ctx = document.getElementById("myChartBurnAreaLastDays");
-                var myLineChart = new Chart(ctx, {
-                    type: 'bar',
-                    data: {
-                        labels: labels,
-                        datasets: [{
-                            label: 'Total',
-                            data: total,
-                            fill: false,
-                            backgroundColor: '#f67e23',
-                            borderColor: '#f67e23'
-                        },
-                        ]
-                    },
-                    options: {
-                        elements: {
-                            line: {
-                                tension: 0, // disables bezier curves
-                                showXLabels: 5,
-                            }
-                        },
-                        responsive: true,
-                        scales: {
-
-                        }
-                    }
-                });
-            } else {
-                $('#info').find('canvas').remove();
-                $('#info').append('<p>Não há dados disponiveis</p> ');
-            }
+        for (d in data.data) {
+          labels.push(d);
+          total.push(data.data[d]);
         }
-    });
+
+        var ctx = document.getElementById("myChartBurnAreaLastDays");
+        var myLineChart = new Chart(ctx, {
+          type: "bar",
+          data: {
+            labels: labels,
+            datasets: [
+              {
+                label: "Total",
+                data: total,
+                fill: false,
+                backgroundColor: "#f67e23",
+                borderColor: "#f67e23",
+              },
+            ],
+          },
+          options: {
+            elements: {
+              line: {
+                tension: 0, // disables bezier curves
+                showXLabels: 5,
+              },
+            },
+            responsive: true,
+            scales: {},
+          },
+        });
+      } else {
+        $("#info")
+          .find("canvas")
+          .remove();
+        $("#info").append("<p>Não há dados disponiveis</p> ");
+      }
+    },
+  });
 }
 
+function plotMotives() {
+  var url = "https://api.fogos.pt/v1/stats/motive";
+  $.ajax({
+    url: url,
+    method: "GET",
+    success: function(data) {
+      if (data.success && data.data) {
+        var labels = [];
+        var total = [];
 
-function plotMotives(){
-    var url = 'https://api.fogos.pt/v1/stats/motive';
-    $.ajax({
-        url: url,
-        method: 'GET',
-        success: function (data) {
-            if (data.success && data.data) {
-                var labels = [];
-                var total = [];
-
-                for (d in data.data) {
-                    labels.push(d);
-                    total.push(data.data[d]);
-                }
-
-                console.log(labels);
-                console.log(total);
-
-                var ctx = document.getElementById("myChartMotives");
-                var myLineChart = new Chart(ctx, {
-                    type: 'bar',
-                    data: {
-                        labels: labels,
-                        datasets: [{
-                            label: 'Total',
-                            data: total,
-                            fill: false,
-                            backgroundColor: '#f67e23',
-                            borderColor: '#f67e23'
-                        },
-                        ]
-                    },
-                    options: {
-                        indexAxis: 'y',
-                        elements: {
-                            line: {
-                                tension: 0, // disables bezier curves
-                                showXLabels: 5,
-                            }
-                        },
-                        responsive: true,
-                        scales: {
-
-                        }
-                    }
-                });
-            } else {
-                $('#info').find('canvas').remove();
-                $('#info').append('<p>Não há dados disponiveis</p> ');
-            }
+        for (d in data.data) {
+          labels.push(d);
+          total.push(data.data[d]);
         }
-    });
+
+        console.log(labels);
+        console.log(total);
+
+        var ctx = document.getElementById("myChartMotives");
+        var myLineChart = new Chart(ctx, {
+          type: "bar",
+          data: {
+            labels: labels,
+            datasets: [
+              {
+                label: "Total",
+                data: total,
+                fill: false,
+                backgroundColor: "#f67e23",
+                borderColor: "#f67e23",
+              },
+            ],
+          },
+          options: {
+            indexAxis: "y",
+            elements: {
+              line: {
+                tension: 0, // disables bezier curves
+                showXLabels: 5,
+              },
+            },
+            responsive: true,
+            scales: {},
+          },
+        });
+      } else {
+        $("#info")
+          .find("canvas")
+          .remove();
+        $("#info").append("<p>Não há dados disponiveis</p> ");
+      }
+    },
+  });
 }
 
 function plot() {
-    var url = 'https://api-lb.fogos.pt/v1/now/data';
-    $.ajax({
-        url: url,
-        method: 'GET',
-        success: function (data) {
-            data = (data);
-            if (data.success && data.data.length) {
-                labels = [];
-                var man = [];
-                var terrain = [];
-                var aerial = [];
-                var total = [];
-                for (d in data.data) {
-                    labels.push(data.data[d].label);
-                    man.push(data.data[d].man);
-                    terrain.push(data.data[d].terrain);
-                    aerial.push(data.data[d].aerial);
-                    total.push(data.data[d].total);
-                }
-
-                var ctx = document.getElementById("myChart");
-                var myLineChart = new Chart(ctx, {
-                    type: 'line',
-                    omitXLabels: true,
-                    data: {
-                        labels: labels,
-                        datasets: [{
-                            label: 'Operacionais',
-                            data: man,
-                            fill: false,
-                            backgroundColor: '#EFC800',
-                            borderColor: '#EFC800'
-                        },
-                            {
-                                label: 'Terrestres',
-                                data: terrain,
-                                fill: false,
-                                backgroundColor: '#6D720B',
-                                borderColor: '#6D720B'
-                            },
-                            {
-                                label: 'Aéreos',
-                                data: aerial,
-                                fill: false,
-                                backgroundColor: '#4E88B2',
-                                borderColor: '#4E88B2'
-                            },
-                            {
-                                label: 'Incêndios ativos',
-                                data: total,
-                                fill: false,
-                                backgroundColor: '#ff512f',
-                                borderColor: '#ff512f'
-                            }]
-                    },
-                    options: {
-                        maintainAspectRatio: false,
-                        elements: {
-                            line: {
-                                tension: 0, // disables bezier curves
-                                showXLabels: 5,
-                            }
-                        },
-                        scales: {
-                            xAxes: [{
-                                ticks: {
-                                    stepSize: 20
-                                }
-                            }]
-                        }
-                    }
-                });
-            } else {
-                $('#info').find('canvas').remove();
-                $('#info').append('<p>Não há dados disponiveis</p> ');
-            }
+  var url = "https://api-lb.fogos.pt/v1/now/data";
+  $.ajax({
+    url: url,
+    method: "GET",
+    success: function(data) {
+      data = data;
+      if (data.success && data.data.length) {
+        labels = [];
+        var man = [];
+        var terrain = [];
+        var aerial = [];
+        var total = [];
+        for (d in data.data) {
+          labels.push(data.data[d].label);
+          man.push(data.data[d].man);
+          terrain.push(data.data[d].terrain);
+          aerial.push(data.data[d].aerial);
+          total.push(data.data[d].total);
         }
-    });
+
+        var ctx = document.getElementById("myChart");
+        var myLineChart = new Chart(ctx, {
+          type: "line",
+          omitXLabels: true,
+          data: {
+            labels: labels,
+            datasets: [
+              {
+                label: "Operacionais",
+                data: man,
+                fill: false,
+                backgroundColor: "#EFC800",
+                borderColor: "#EFC800",
+              },
+              {
+                label: "Terrestres",
+                data: terrain,
+                fill: false,
+                backgroundColor: "#6D720B",
+                borderColor: "#6D720B",
+              },
+              {
+                label: "Aéreos",
+                data: aerial,
+                fill: false,
+                backgroundColor: "#4E88B2",
+                borderColor: "#4E88B2",
+              },
+              {
+                label: "Incêndios ativos",
+                data: total,
+                fill: false,
+                backgroundColor: "#ff512f",
+                borderColor: "#ff512f",
+              },
+            ],
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            elements: {
+              line: {
+                tension: 0, // disables bezier curves
+                showXLabels: 5,
+              },
+            },
+            scales: {
+              xAxes: {
+                ticks: {
+                  stepSize: 20,
+                },
+              },
+            },
+          },
+        });
+      } else {
+        $("#info")
+          .find("canvas")
+          .remove();
+        $("#info").append("<p>Não há dados disponiveis</p> ");
+      }
+    },
+  });
 }
 
 function plotWeekStats() {
-    var url = 'https://api-lb.fogos.pt/v1/stats/week';
-    $.ajax({
-        url: url,
-        method: 'GET',
-        success: function (data) {
-            data = (data);
-            if (data.success && data.data.length) {
-                labels = [];
-                var total = [];
-                var falseFires = [];
-                for (d in data.data) {
-                    labels.push(data.data[d].label);
-                    falseFires.push(data.data[d].false);
-                    total.push(data.data[d].total);
-                }
-
-                var ctx = document.getElementById("myChartStatsWeek");
-                var myLineChart = new Chart(ctx, {
-                    type: 'bar',
-                    data: {
-                        labels: labels,
-                        datasets: [{
-                            label: 'Total',
-                            data: total,
-                            fill: false,
-                            backgroundColor: '#f67e23',
-                            borderColor: '#f67e23'
-                        },
-                            {
-                                label: 'Falsos Alarmes',
-                                data: falseFires,
-                                fill: false,
-                                backgroundColor: '#000000',
-                                borderColor: '#000000'
-                            },
-                        ]
-                    },
-                    options: {
-                        elements: {
-                            line: {
-                                tension: 0, // disables bezier curves
-                                showXLabels: 5,
-                            }
-                        },
-                        responsive: true,
-                        scales: {
-
-                        }
-                    }
-                });
-            } else {
-                $('#info').find('canvas').remove();
-                $('#info').append('<p>Não há dados disponiveis</p> ');
-            }
+  var url = "https://api-lb.fogos.pt/v1/stats/week";
+  $.ajax({
+    url: url,
+    method: "GET",
+    success: function(data) {
+      data = data;
+      if (data.success && data.data.length) {
+        labels = [];
+        var total = [];
+        var falseFires = [];
+        for (d in data.data) {
+          labels.push(data.data[d].label);
+          falseFires.push(data.data[d].false);
+          total.push(data.data[d].total);
         }
-    });
+
+        var ctx = document.getElementById("myChartStatsWeek");
+        var myLineChart = new Chart(ctx, {
+          type: "bar",
+          data: {
+            labels: labels,
+            datasets: [
+              {
+                label: "Total",
+                data: total,
+                fill: false,
+                backgroundColor: "#f67e23",
+                borderColor: "#f67e23",
+              },
+              {
+                label: "Falsos Alarmes",
+                data: falseFires,
+                fill: false,
+                backgroundColor: "#000000",
+                borderColor: "#000000",
+              },
+            ],
+          },
+          options: {
+            elements: {
+              line: {
+                tension: 0, // disables bezier curves
+                showXLabels: 5,
+              },
+            },
+            responsive: true,
+            scales: {},
+          },
+        });
+      } else {
+        $("#info")
+          .find("canvas")
+          .remove();
+        $("#info").append("<p>Não há dados disponiveis</p> ");
+      }
+    },
+  });
 }
 
 function plotStats8hours() {
-    var url = 'https://api-lb.fogos.pt/v1/stats/8hours';
-    $.ajax({
-        url: url,
-        method: 'GET',
-        success: function (data) {
-            data = (data);
-            if (data.success && data.data) {
-                var labels = [];
-                var total = [];
+  var url = "https://api-lb.fogos.pt/v1/stats/8hours";
+  $.ajax({
+    url: url,
+    method: "GET",
+    success: function(data) {
+      data = data;
+      if (data.success && data.data) {
+        var labels = [];
+        var total = [];
 
-                for (d in data.data) {
-                    labels.push(d);
-                    total.push(data.data[d].total);
-                }
-
-                var ctx = document.getElementById("myChartStats8hours");
-                var myLineChart = new Chart(ctx, {
-                    type: 'bar',
-                    data: {
-                        labels: labels,
-                        datasets: [{
-                            label: 'Total',
-                            data: total,
-                            fill: false,
-                            backgroundColor: '#f67e23',
-                            borderColor: '#f67e23'
-                        },
-                        ]
-                    },
-                    options: {
-                        elements: {
-                            line: {
-                                tension: 0, // disables bezier curves
-                                showXLabels: 5,
-                            }
-                        },
-                        responsive: true,
-                        scales: {
-
-                        }
-                    }
-                });
-            } else {
-                $('#info').find('canvas').remove();
-                $('#info').append('<p>Não há dados disponiveis</p> ');
-            }
+        for (d in data.data) {
+          labels.push(d);
+          total.push(data.data[d].total);
         }
-    });
+
+        var ctx = document.getElementById("myChartStats8hours");
+        var myLineChart = new Chart(ctx, {
+          type: "bar",
+          data: {
+            labels: labels,
+            datasets: [
+              {
+                label: "Total",
+                data: total,
+                fill: false,
+                backgroundColor: "#f67e23",
+                borderColor: "#f67e23",
+              },
+            ],
+          },
+          options: {
+            elements: {
+              line: {
+                tension: 0, // disables bezier curves
+                showXLabels: 5,
+              },
+            },
+            responsive: true,
+            scales: {},
+          },
+        });
+      } else {
+        $("#info")
+          .find("canvas")
+          .remove();
+        $("#info").append("<p>Não há dados disponiveis</p> ");
+      }
+    },
+  });
 }
 
 function plotStatsLastNight() {
-    var url = 'https://api-lb.fogos.pt/v1/stats/last-night';
+  var url = "https://api-lb.fogos.pt/v1/stats/last-night";
 
-    $.ajax({
-        url: url,
-        method: 'GET',
-        success: function (data) {
-            data = (data);
-            if (data.success && data.data) {
-                var labels = [];
-                var total = [];
-                var colors = [];
+  $.ajax({
+    url: url,
+    method: "GET",
+    success: function(data) {
+      data = data;
+      if (data.success && data.data) {
+        var labels = [];
+        var total = [];
+        var colors = [];
 
-                for (d in data.data.distritos) {
-                    labels.push(d);
-                    total.push(data.data.distritos[d]);
-                    colors.push(getColor(d));
-                }
-
-                var ctx = document.getElementById("myChartStatsLastNight");
-                var myLineChart = new Chart(ctx, {
-                    type: 'doughnut',
-                    data: {
-                        labels: labels,
-                        datasets: [{
-                            label: 'Incêndios',
-                            data: total,
-                            backgroundColor: colors,
-                        },
-                        ]
-                    },
-                });
-
-            } else {
-                $('#info').find('canvas').remove();
-                $('#info').append('<p>Não há dados disponiveis</p> ');
-            }
+        for (d in data.data.distritos) {
+          labels.push(d);
+          total.push(data.data.distritos[d]);
+          colors.push(getColor(d));
         }
-    });
+
+        var ctx = document.getElementById("myChartStatsLastNight");
+        var myLineChart = new Chart(ctx, {
+          type: "doughnut",
+          data: {
+            labels: labels,
+            datasets: [
+              {
+                label: "Incêndios",
+                data: total,
+                backgroundColor: colors,
+              },
+            ],
+          },
+        });
+      } else {
+        $("#info")
+          .find("canvas")
+          .remove();
+        $("#info").append("<p>Não há dados disponiveis</p> ");
+      }
+    },
+  });
 }
 
 function plotStats8hoursYesterday() {
-    var url = 'https://api-lb.fogos.pt/v1/stats/8hours/yesterday';
-    $.ajax({
-        url: url,
-        method: 'GET',
-        success: function (data) {
-            data = (data);
-            if (data.success && data.data) {
-                var labels = [];
-                var total = [];
+  var url = "https://api-lb.fogos.pt/v1/stats/8hours/yesterday";
+  $.ajax({
+    url: url,
+    method: "GET",
+    success: function(data) {
+      data = data;
+      if (data.success && data.data) {
+        var labels = [];
+        var total = [];
 
-                for (d in data.data) {
-                    labels.push(d);
-                    total.push(data.data[d].total);
-                }
-
-                var ctx = document.getElementById("myChartStats8hoursYesterday");
-                var myLineChart = new Chart(ctx, {
-                    type: 'bar',
-                    data: {
-                        labels: labels,
-                        datasets: [{
-                            label: 'Total',
-                            data: total,
-                            fill: false,
-                            backgroundColor: '#f67e23',
-                            borderColor: '#f67e23'
-                        },
-                        ]
-                    },
-                    options: {
-                        elements: {
-                            line: {
-                                tension: 0, // disables bezier curves
-                                showXLabels: 5,
-                            }
-                        },
-                        responsive: true,
-                        scales: {
-
-                        }
-                    }
-                });
-            } else {
-                $('#info').find('canvas').remove();
-                $('#info').append('<p>Não há dados disponiveis</p> ');
-            }
+        for (d in data.data) {
+          labels.push(d);
+          total.push(data.data[d].total);
         }
-    });
+
+        var ctx = document.getElementById("myChartStats8hoursYesterday");
+        var myLineChart = new Chart(ctx, {
+          type: "bar",
+          data: {
+            labels: labels,
+            datasets: [
+              {
+                label: "Total",
+                data: total,
+                fill: false,
+                backgroundColor: "#f67e23",
+                borderColor: "#f67e23",
+              },
+            ],
+          },
+          options: {
+            elements: {
+              line: {
+                tension: 0, // disables bezier curves
+                showXLabels: 5,
+              },
+            },
+            responsive: true,
+            scales: {},
+          },
+        });
+      } else {
+        $("#info")
+          .find("canvas")
+          .remove();
+        $("#info").append("<p>Não há dados disponiveis</p> ");
+      }
+    },
+  });
 }
-
-
 
 function plotStatsTotal() {
+  var values;
 
-    var values;
+  var url = "https://api-lb.fogos.pt/v1/stats/today";
+  $.ajax({
+    url: url,
+    method: "GET",
+    success: function(data) {
+      data = data;
+      if (data.success && data.data) {
+        // control that shows state info on hover
+        var info = L.control();
 
-    var url = 'https://api-lb.fogos.pt/v1/stats/today';
-    $.ajax({
-        url: url,
-        method: 'GET',
-        success: function (data) {
-            data = (data);
-            if (data.success && data.data) {
+        info.onAdd = function(map) {
+          this._div = L.DomUtil.create("div", "info");
+          this.update();
+          return this._div;
+        };
 
-                // control that shows state info on hover
-                var info = L.control();
+        info.update = function(props, incendios) {
+          this._div.innerHTML =
+            "<h6>Incêndios totais</h6>" +
+            (props
+              ? "<b>" +
+                props.name +
+                "</b><br />" +
+                incendios +
+                " incêndios</sup>"
+              : "Clique num distrito");
+        };
 
-                info.onAdd = function(map) {
-                    this._div = L.DomUtil.create('div', 'info');
-                    this.update();
-                    return this._div;
-                };
+        info.addTo(map);
 
+        function getColor(d) {
+          return d > 40
+            ? "#BD0026"
+            : d > 20
+            ? "#E31A1C"
+            : d > 10
+            ? "#FC4E2A"
+            : d > 5
+            ? "#FD8D3C"
+            : d > 0
+            ? "#FEB24C"
+            : "#99ff66";
+        }
 
-                info.update = function(props, incendios) {
-                        this._div.innerHTML = '<h6>Incêndios totais</h6>' + (props ?
-                            '<b>' + props.name + '</b><br />' + incendios + ' incêndios</sup>' :
-                            'Clique num distrito');
-                };
+        function style(feature) {
+          var incendios = "0";
 
+          if (data.data.distritos[feature.properties.name] != null) {
+            incendios = data.data.distritos[feature.properties.name];
+          }
 
+          return {
+            weight: 2,
+            opacity: 1,
+            color: "white",
+            dashArray: "3",
+            fillOpacity: 0.7,
+            fillColor: getColor(incendios),
+          };
+        }
 
-                info.addTo(map);
+        function highlightFeature(e) {
+          var layer = e.target;
 
+          layer.setStyle({
+            weight: 5,
+            color: "#666",
+            dashArray: "",
+            fillOpacity: 0.7,
+          });
 
-                function getColor(d) {
-                    return d > 40 ? '#BD0026' :
-                        d > 20 ? '#E31A1C' :
-                        d > 10 ? '#FC4E2A' :
-                        d > 5 ? '#FD8D3C' :
-                        d > 0 ? '#FEB24C' :
-                        '#99ff66';
-                }
+          if (!L.Browser.ie && !L.Browser.opera && !L.Browser.edge) {
+            layer.bringToFront();
+          }
 
-                function style(feature) {
+          var incendios = "0";
 
+          if (data.data.distritos[layer.feature.properties.name] != null) {
+            incendios = data.data.distritos[layer.feature.properties.name];
+          }
 
-                    var incendios = '0';
+          info.update(layer.feature.properties, incendios);
+        }
 
-                    if(data.data.distritos[feature.properties.name] != null){
-                        incendios = data.data.distritos[feature.properties.name];
-                    }
+        var geojson;
 
+        function resetHighlight(e) {
+          geojson.resetStyle(e.target);
+          info.update();
+        }
 
-                    return {
-                        weight: 2,
-                        opacity: 1,
-                        color: 'white',
-                        dashArray: '3',
-                        fillOpacity: 0.7,
-                        fillColor: getColor(incendios)
-                    };
-                }
+        function zoomToFeature(e) {
+          map.fitBounds(e.target.getBounds());
+        }
 
-                function highlightFeature(e) {
-                    var layer = e.target;
+        function onEachFeature(feature, layer) {
+          layer.on({
+            mouseover: highlightFeature,
+            mouseout: resetHighlight,
+            click: zoomToFeature,
+          });
+        }
 
-                    layer.setStyle({
-                        weight: 5,
-                        color: '#666',
-                        dashArray: '',
-                        fillOpacity: 0.7
-                    });
+        geojson = L.geoJson(distritos, {
+          style: style,
+          onEachFeature: onEachFeature,
+        }).addTo(map);
 
-                    if (!L.Browser.ie && !L.Browser.opera && !L.Browser.edge) {
-                        layer.bringToFront();
-                    }
+        var legend = L.control({
+          position: "bottomright",
+        });
 
+        legend.onAdd = function(map) {
+          var div = L.DomUtil.create("div", "info legend"),
+            grades = [0, 1, 5, 10, 20, 40],
+            labels = [],
+            from,
+            to;
 
-                    var incendios = '0';
+          labels.push(
+            '<i style="background:' + getColor(from + 1) + '"></i> ' + "0"
+          );
+          for (var i = 1; i < grades.length; i++) {
+            from = grades[i];
+            to = grades[i + 1];
 
-                    if(data.data.distritos[layer.feature.properties.name] != null){
-                        incendios = data.data.distritos[layer.feature.properties.name];
-                    }
+            labels.push(
+              '<i style="background:' +
+                getColor(from + 1) +
+                '"></i> ' +
+                from +
+                (to ? "&ndash;" + to : "+")
+            );
+          }
 
-                    info.update(layer.feature.properties,incendios);
-                }
+          div.innerHTML = labels.join("<br>");
+          return div;
+        };
 
+        legend.addTo(map);
+      }
+    },
+  });
 
-
-
-                var geojson;
-
-                function resetHighlight(e) {
-                    geojson.resetStyle(e.target);
-                    info.update();
-                }
-
-
-                function zoomToFeature(e) {
-                    map.fitBounds(e.target.getBounds());
-                }
-
-                function onEachFeature(feature, layer) {
-                    layer.on({
-                        mouseover: highlightFeature,
-                        mouseout: resetHighlight,
-                        click: zoomToFeature
-                    });
-                }
-
-                geojson = L.geoJson(distritos, {
-                    style: style,
-                    onEachFeature: onEachFeature
-                }).addTo(map);
-
-
-
-
-                var legend = L.control({
-                    position: 'bottomright'
-                });
-
-                legend.onAdd = function(map) {
-
-                    var div = L.DomUtil.create('div', 'info legend'),
-                        grades = [0, 1, 5, 10, 20, 40],
-                        labels = [],
-                        from, to;
-
-                    labels.push(
-                            '<i style="background:' + getColor(from + 1) + '"></i> ' +
-                            '0');
-                    for (var i = 1; i < grades.length; i++) {
-                        from = grades[i];
-                        to = grades[i + 1];
-
-                        labels.push(
-                            '<i style="background:' + getColor(from + 1) + '"></i> ' +
-                            from + (to ? '&ndash;' + to : '+'));
-                    }
-
-                    div.innerHTML = labels.join('<br>');
-                    return div;
-                };
-
-                legend.addTo(map);
-
-
-
-              }
-            }
-    });
-
-
-
-    var map = L.map('mapid').setView([39.6, -7.9], 7);
-    var normalLayer = L.tileLayer('https://api.mapbox.com/styles/v1/fogospt/cjgppvcdp00aa2spjclz9sjst/tiles/256/{z}/{x}/{y}@2x?access_token='+window.mapboxKey, {
-        attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
-        maxZoom: 18,
-        id: 'mapbox.streets',
-        accessToken: window.mapboxKey
-    }).addTo(map)
-
-
-
-
-
-
+  var map = L.map("mapid").setView([39.6, -7.9], 7);
+  var normalLayer = L.tileLayer(
+    "https://api.mapbox.com/styles/v1/fogospt/cjgppvcdp00aa2spjclz9sjst/tiles/256/{z}/{x}/{y}@2x?access_token=" +
+      window.mapboxKey,
+    {
+      attribution:
+        'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+      maxZoom: 18,
+      id: "mapbox.streets",
+      accessToken: window.mapboxKey,
+    }
+  ).addTo(map);
 }
 
-
-
 function plotStatsYesterdayDistricts() {
-    var url = 'https://api-lb.fogos.pt/v1/stats/yesterday';
+  var url = "https://api-lb.fogos.pt/v1/stats/yesterday";
 
-    $.ajax({
-        url: url,
-        method: 'GET',
-        success: function (data) {
-            if (data.success && data.data) {
-                var labels = [];
-                var total = [];
-                var colors = [];
+  $.ajax({
+    url: url,
+    method: "GET",
+    success: function(data) {
+      if (data.success && data.data) {
+        var labels = [];
+        var total = [];
+        var colors = [];
 
-                for (d in data.data.distritos) {
-                    labels.push(d);
-                    total.push(data.data.distritos[d]);
-                    colors.push(getColor(d));
-                }
-
-                var ctx = document.getElementById("myChartStatsYesterday");
-                var myLineChart = new Chart(ctx, {
-                    type: 'doughnut',
-                    data: {
-                        labels: labels,
-                        datasets: [{
-                            label: 'Total',
-                            data: total,
-                            backgroundColor: colors,
-                        },
-                        ]
-                    },
-                });
-
-            } else {
-                $('#info').find('canvas').remove();
-                $('#info').append('<p>Não há dados disponiveis</p> ');
-            }
+        for (d in data.data.distritos) {
+          labels.push(d);
+          total.push(data.data.distritos[d]);
+          colors.push(getColor(d));
         }
-    });
+
+        var ctx = document.getElementById("myChartStatsYesterday");
+        var myLineChart = new Chart(ctx, {
+          type: "doughnut",
+          data: {
+            labels: labels,
+            datasets: [
+              {
+                label: "Total",
+                data: total,
+                backgroundColor: colors,
+              },
+            ],
+          },
+        });
+      } else {
+        $("#info")
+          .find("canvas")
+          .remove();
+        $("#info").append("<p>Não há dados disponiveis</p> ");
+      }
+    },
+  });
 }
 
 function plotStatsDistricts() {
-    var url = 'https://api-lb.fogos.pt/v1/stats/today';
+  var url = "https://api-lb.fogos.pt/v1/stats/today";
 
-    $.ajax({
-        url: url,
-        method: 'GET',
-        success: function (data) {
-            if (data.success && data.data) {
-                var labels = [];
-                var total = [];
-                var colors = [];
+  $.ajax({
+    url: url,
+    method: "GET",
+    success: function(data) {
+      if (data.success && data.data) {
+        var labels = [];
+        var total = [];
+        var colors = [];
 
-                for (d in data.data.distritos) {
-                    labels.push(d);
-                    total.push(data.data.distritos[d]);
-                    colors.push(getColor(d));
-                }
-
-                var ctx = document.getElementById("myChartStatsToday");
-                var myLineChart = new Chart(ctx, {
-                    type: 'doughnut',
-                    data: {
-                        labels: labels,
-                        datasets: [{
-                            label: 'Total',
-                            data: total,
-                            backgroundColor: colors,
-                        },
-                        ]
-                    },
-                });
-
-            } else {
-                $('#info').find('canvas').remove();
-                $('#info').append('<p>Não há dados disponiveis</p> ');
-            }
+        for (d in data.data.distritos) {
+          labels.push(d);
+          total.push(data.data.distritos[d]);
+          colors.push(getColor(d));
         }
-    });
+
+        var ctx = document.getElementById("myChartStatsToday");
+        var myLineChart = new Chart(ctx, {
+          type: "doughnut",
+          data: {
+            labels: labels,
+            datasets: [
+              {
+                label: "Total",
+                data: total,
+                backgroundColor: colors,
+              },
+            ],
+          },
+        });
+      } else {
+        $("#info")
+          .find("canvas")
+          .remove();
+        $("#info").append("<p>Não há dados disponiveis</p> ");
+      }
+    },
+  });
 }
 
+function getColor(str) {
+  var dColors = {
+    Aveiro: "#4462a0",
+    Beja: "#ffa600",
+    Braga: "#2f4b7c",
+    Bragança: "#a05195",
+    "Castelo Branco": "#ee598e",
+    Coimbra: "#d65a9e",
+    Évora: "#ff932c",
+    Faro: "#ef9c00",
+    Guarda: "#b95da9",
+    Leiria: "#ff5f7a",
+    Lisboa: "#ff9030",
+    Portalegre: "#ff7b4b",
+    Porto: "#005b85",
+    Santarém: "#ff6a64",
+    Setúbal: "#ff9f16",
+    "Viana do Castelo": "#003f5c",
+    "Vila Real": "#665191",
+    Viseu: "#7f62ad",
+  };
 
-function getColor(str)
-{
-    var dColors = {
-        'Aveiro': '#4462a0',
-        'Beja': '#ffa600',
-        'Braga': '#2f4b7c',
-        'Bragança': '#a05195',
-        'Castelo Branco': '#ee598e',
-        'Coimbra': '#d65a9e',
-        'Évora': '#ff932c',
-        'Faro': '#ef9c00',
-        'Guarda': '#b95da9',
-        'Leiria': '#ff5f7a',
-        'Lisboa': '#ff9030',
-        'Portalegre': '#ff7b4b',
-        'Porto': '#005b85',
-        'Santarém': '#ff6a64',
-        'Setúbal': '#ff9f16',
-        'Viana do Castelo': '#003f5c',
-        'Vila Real': '#665191',
-        'Viseu': '#7f62ad',
-    };
-
-    return dColors[str];
+  return dColors[str];
 }
-
-
 
 function getParameterByName(name, url) {
-    if (!url) url = window.location.href;
-    name = name.replace(/[\[\]]/g, "\\$&");
-    var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
-        results = regex.exec(url);
-    if (!results) return null;
-    if (!results[2]) return '';
-    return decodeURIComponent(results[2].replace(/\+/g, " "));
+  if (!url) url = window.location.href;
+  name = name.replace(/[\[\]]/g, "\\$&");
+  var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),
+    results = regex.exec(url);
+  if (!results) return null;
+  if (!results[2]) return "";
+  return decodeURIComponent(results[2].replace(/\+/g, " "));
 }

--- a/fogospt/resources/views/stats.blade.php
+++ b/fogospt/resources/views/stats.blade.php
@@ -1,231 +1,225 @@
 @extends('app')
 
 @push('head')
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.4.0/dist/leaflet.css"
-   integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA=="
-   crossorigin="">
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.4.0/dist/leaflet.css" integrity="sha512-puBpdR0798OZvTTbP4A8Ix/l+A4dHDD0DGqYW6RQ+9jxkRFclaxxQb/SJAWZfWAkuyeQUytO7+7N4QKrDh+drA==" crossorigin="">
 
 @endpush
 
 @section('content')
-    <main role="main" class="mb-auto margin-top-10">
-        <div class="container">
+<main role="main" class="mb-auto margin-top-10">
+    <div class="container">
 
-            <div class="row align-items-stretch">
-                <div class="col-12">
-                    <h1>@lang('includes.menu.stats')</h1>
-                </div>
+        <div class="row align-items-stretch">
+            <div class="col-12">
+                <h1>@lang('includes.menu.stats')</h1>
             </div>
+        </div>
 
-            <section class="card flex-column flex-md-row align-items-stretch stats">
-                <div class="col-12 col-md-6 px-0">
-                    <div class="card">
-                        <div class="card-body">
-                            <h4 class="card-title">@lang('pages.stats.now-text')</h4>
-                            <div class="d-flex justify-content-between">
-                                <div class="assets d-flex align-items-center justify-content-center">
-                                    <div class="d-flex flex-column">
-                                        <div class="d-flex flex-row align-items-center">
-                                            <img class="assets-icon" src="/img/logo_flame.svg">
-                                            <span class="assets-nr f-man">
-                                                @isset($data['now']['total'])
-                                                {{ $data['now']['total'] }}
-                                                @endisset
-                                            </span>
-                                        </div>
-                                        <div class="d-flex flex-row align-items-center">
-                                            <img class="assets-icon" src="/img/fireman.svg">
-                                            <span class="assets-nr f-man">
-                                                @isset($data['now']['man'])
-                                                {{ $data['now']['man'] }}
-                                                @endisset
-                                            </span>
-                                        </div>
+        <section class="card flex-column flex-md-row align-items-stretch stats">
+            <div class="col-12 col-md-6 px-0 ">
+                <div class="card">
+                    <div class="card-body">
+                        <h4 class="card-title">@lang('pages.stats.now-text')</h4>
+                        <div class="d-flex justify-content-between">
+                            <div class="assets d-flex align-items-center justify-content-center">
+                                <div class="d-flex flex-column">
+                                    <div class="d-flex flex-row align-items-center">
+                                        <img class="assets-icon" src="/img/logo_flame.svg">
+                                        <span class="assets-nr f-man">
+                                            @isset($data['now']['total'])
+                                            {{ $data['now']['total'] }}
+                                            @endisset
+                                        </span>
                                     </div>
-                                    <div class="d-flex flex-column p-4">
-                                        <div class="d-flex flex-row align-items-center">
-                                            <img class="assets-icon" src="/img/firetruck.svg">
-                                            <span class="assets-nr f-terrain">
-                                                @isset($data['now']['cars'])
-                                                {{ $data['now']['cars'] }}
-                                                @endisset
-                                            </span>
-                                        </div>
-                                        <div class="d-flex flex-row align-items-center">
-                                            <img class="assets-icon" src="/img/plane.svg">
-                                            <span class="assets-nr f-aerial">
-                                                @isset($data['now']['aerial'])
-                                                {{ $data['now']['aerial'] }}
-                                                @endisset
-                                            </span>
-                                        </div>
+                                    <div class="d-flex flex-row align-items-center">
+                                        <img class="assets-icon" src="/img/fireman.svg">
+                                        <span class="assets-nr f-man">
+                                            @isset($data['now']['man'])
+                                            {{ $data['now']['man'] }}
+                                            @endisset
+                                        </span>
+                                    </div>
+                                </div>
+                                <div class="d-flex flex-column p-4">
+                                    <div class="d-flex flex-row align-items-center">
+                                        <img class="assets-icon" src="/img/firetruck.svg">
+                                        <span class="assets-nr f-terrain">
+                                            @isset($data['now']['cars'])
+                                            {{ $data['now']['cars'] }}
+                                            @endisset
+                                        </span>
+                                    </div>
+                                    <div class="d-flex flex-row align-items-center">
+                                        <img class="assets-icon" src="/img/plane.svg">
+                                        <span class="assets-nr f-aerial">
+                                            @isset($data['now']['aerial'])
+                                            {{ $data['now']['aerial'] }}
+                                            @endisset
+                                        </span>
                                     </div>
                                 </div>
                             </div>
-                            <div class="d-flex justify-content-between">
-                                <p>
-                                    <small>@lang('pages.stats.now.footer')</small>
-                                </p>
-                            </div>
+                        </div>
+                        <div class="d-flex justify-content-between">
+                            <p>
+                                <small>@lang('pages.stats.now.footer')</small>
+                            </p>
                         </div>
                     </div>
                 </div>
-                <canvas style="padding: 0 5px" id="myChart" class="col-12 col-md-6 px-0"></canvas>
-            </section>
+            </div>
+            <div class="col-12 col-md-6 px-2 py-2" style="min-height: 40vh;">
+                <canvas id="myChart"></canvas>
+            </div>
+        </section>
 
-            <section class="row phantom-hide">
-                <section class="col-12 col-md-6">
-                    <section class="card flex-column flex-md-row align-items-stretch stats">
-                        <div class="col-12 px-0">
-                            <div class="card">
-                                <div class="card-body">
-                                    <h4 class="card-title">@lang('pages.stats.today')</h4>
-                                    <canvas style="padding: 0 5px" id="myChartStats8hours"
-                                            class="col-12 px-0"></canvas>
-                                </div>
+        <section class="row phantom-hide">
+            <section class="col-12 col-md-6">
+                <section class="card flex-column flex-md-row align-items-stretch stats">
+                    <div class="col-12 px-0">
+                        <div class="card">
+                            <div class="card-body">
+                                <h4 class="card-title">@lang('pages.stats.today')</h4>
+                                <canvas style="padding: 0 5px" id="myChartStats8hours" class="col-12 px-0"></canvas>
                             </div>
                         </div>
-                    </section>
-
-                    <section class="card flex-column flex-md-row align-items-stretch stats">
-                        <div class="col-12 px-0">
-                            <div class="card">
-                                <div class="card-body">
-                                    <h4 class="card-title">@lang('pages.stats.yesterday')</h4>
-                                    <canvas style="padding: 0 5px" id="myChartStatsYesterday"
-                                            class="col-12 px-0"></canvas>
-                                </div>
-                            </div>
-                        </div>
-                    </section>
-
-                    <section class="card flex-column flex-md-row align-items-stretch stats">
-                        <div class="col-12 col-md-12 px-0">
-                            <div class="card">
-                                <div class="card-body">
-                                    <h4 class="card-title">@lang('pages.stats.last-days')</h4>
-                                    <canvas style="padding: 0 5px" id="myChartStatsWeek"
-                                            class="col-12 col-md-12 px-0"></canvas>
-                                </div>
-                            </div>
-                        </div>
-                    </section>
-
-
-                    <section class="card flex-column flex-md-row align-items-stretch stats">
-                        <div class="col-12 px-0">
-                            <div class="card">
-                                <div class="card-body">
-                                    <h4 class="card-title">@lang('pages.stats.today')</h4>
-
-                                     <div id="mapid" style="height:700px; "></div>
-
-
-                                </div>
-                            </div>
-                        </div>
-                    </section>
+                    </div>
                 </section>
 
-                <section class="col-12 col-md-6">
-                    <section class="card flex-column flex-md-row align-items-stretch stats">
-                        <div class="col-12 px-0">
-                            <div class="card">
-                                <div class="card-body">
-                                    <h4 class="card-title">@lang('pages.stats.today')</h4>
-                                    <canvas style="padding: 0 5px" id="myChartStatsToday"
-                                            class="col-12 px-0"></canvas>
-                                </div>
+                <section class="card flex-column flex-md-row align-items-stretch stats">
+                    <div class="col-12 px-0">
+                        <div class="card">
+                            <div class="card-body">
+                                <h4 class="card-title">@lang('pages.stats.yesterday')</h4>
+                                <canvas style="padding: 0 5px" id="myChartStatsYesterday" class="col-12 px-0"></canvas>
                             </div>
                         </div>
-                    </section>
-
-                    <section class="card flex-column flex-md-row align-items-stretch stats">
-                        <div class="col-12 px-0">
-                            <div class="card">
-                                <div class="card-body">
-                                    <h4 class="card-title">@lang('pages.stats.yesterday')</h4>
-                                    <canvas style="padding: 0 5px" id="myChartStats8hoursYesterday"
-                                            class="col-12 px-0"></canvas>
-                                </div>
-                            </div>
-                        </div>
-                    </section>
-
-                    <section class="card flex-column flex-md-row align-items-stretch stats">
-                        <div class="col-12 px-0">
-                            <div class="card">
-                                <div class="card-body">
-                                    <h4 class="card-title">@lang('pages.stats.last-night')</h4>
-                                    <canvas style="padding: 0 5px" id="myChartStatsLastNight"
-                                            class="col-12 px-0"></canvas>
-                                    <div class="d-flex justify-content-between">
-                                        <p>
-                                            <small>@lang('pages.stats.last-night-footer')</small>
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </section>
-
-
-                    <section class="card flex-column flex-md-row align-items-stretch stats">
-                        <div class="col-12 px-0">
-                            <div class="card">
-                                <div class="card-body">
-                                    <h4 class="card-title">@lang('pages.stats.burn-area-last-days')</h4>
-                                    <canvas style="padding: 0 5px" id="myChartBurnAreaLastDays"
-                                            class="col-12 px-0"></canvas>
-                                    <div class="d-flex justify-content-between">
-                                        <p>
-                                            <small>@lang('pages.stats.burn-area-last-days-footer')</small>
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </section>
-
-
-
-                    <section class="card flex-column flex-md-row align-items-stretch stats">
-                        <div class="col-12 px-0">
-                            <div class="card">
-                                <div class="card-body">
-                                    <h4 class="card-title">@lang('pages.stats.motives.title')</h4>
-                                    <canvas style="padding: 0 5px" id="myChartMotives"
-                                            class="col-12 px-0"></canvas>
-                                    <div class="d-flex justify-content-between">
-                                        <p>
-                                            <small>@lang('pages.stats.motives.footer')</small>
-                                        </p>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </section>
-
-
-
+                    </div>
                 </section>
 
+                <section class="card flex-column flex-md-row align-items-stretch stats">
+                    <div class="col-12 col-md-12 px-0">
+                        <div class="card">
+                            <div class="card-body">
+                                <h4 class="card-title">@lang('pages.stats.last-days')</h4>
+                                <canvas style="padding: 0 5px" id="myChartStatsWeek" class="col-12 col-md-12 px-0"></canvas>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+
+                <section class="card flex-column flex-md-row align-items-stretch stats">
+                    <div class="col-12 px-0">
+                        <div class="card">
+                            <div class="card-body">
+                                <h4 class="card-title">@lang('pages.stats.today')</h4>
+
+                                <div id="mapid" style="height:700px; "></div>
+
+
+                            </div>
+                        </div>
+                    </div>
+                </section>
             </section>
-        </div>
-    </main>
+
+            <section class="col-12 col-md-6">
+                <section class="card flex-column flex-md-row align-items-stretch stats">
+                    <div class="col-12 px-0">
+                        <div class="card">
+                            <div class="card-body">
+                                <h4 class="card-title">@lang('pages.stats.today')</h4>
+                                <canvas style="padding: 0 5px" id="myChartStatsToday" class="col-12 px-0"></canvas>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="card flex-column flex-md-row align-items-stretch stats">
+                    <div class="col-12 px-0">
+                        <div class="card">
+                            <div class="card-body">
+                                <h4 class="card-title">@lang('pages.stats.yesterday')</h4>
+                                <canvas style="padding: 0 5px" id="myChartStats8hoursYesterday" class="col-12 px-0"></canvas>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="card flex-column flex-md-row align-items-stretch stats">
+                    <div class="col-12 px-0">
+                        <div class="card">
+                            <div class="card-body">
+                                <h4 class="card-title">@lang('pages.stats.last-night')</h4>
+                                <canvas style="padding: 0 5px" id="myChartStatsLastNight" class="col-12 px-0"></canvas>
+                                <div class="d-flex justify-content-between">
+                                    <p>
+                                        <small>@lang('pages.stats.last-night-footer')</small>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+
+                <section class="card flex-column flex-md-row align-items-stretch stats">
+                    <div class="col-12 px-0">
+                        <div class="card">
+                            <div class="card-body">
+                                <h4 class="card-title">@lang('pages.stats.burn-area-last-days')</h4>
+                                <canvas style="padding: 0 5px" id="myChartBurnAreaLastDays" class="col-12 px-0"></canvas>
+                                <div class="d-flex justify-content-between">
+                                    <p>
+                                        <small>@lang('pages.stats.burn-area-last-days-footer')</small>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+
+
+                <section class="card flex-column flex-md-row align-items-stretch stats">
+                    <div class="col-12 px-0">
+                        <div class="card">
+                            <div class="card-body">
+                                <h4 class="card-title">@lang('pages.stats.motives.title')</h4>
+                                <canvas style="padding: 0 5px" id="myChartMotives" class="col-12 px-0"></canvas>
+                                <div class="d-flex justify-content-between">
+                                    <p>
+                                        <small>@lang('pages.stats.motives.footer')</small>
+                                    </p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </section>
+
+
+
+            </section>
+
+        </section>
+    </div>
+</main>
 @endsection
 
 @push('scripts')
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.8.0/chart.min.js" integrity="sha512-sW/w8s4RWTdFFSduOTGtk4isV1+190E/GghVffMA9XczdJ2MDzSzLEubKAs5h0wzgSJOQTRYyaz73L3d6RtJSg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script> window.mapboxKey = '{{ env('MAPBOX_TOKEN') }}' </script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.8.0/chart.min.js" integrity="sha512-sW/w8s4RWTdFFSduOTGtk4isV1+190E/GghVffMA9XczdJ2MDzSzLEubKAs5h0wzgSJOQTRYyaz73L3d6RtJSg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script>
+    window.mapboxKey = '{{ env('
+    MAPBOX_TOKEN ') }}'
 
-    <script src="js/stats.js"></script>
+</script>
 
-    <script src="https://unpkg.com/leaflet@1.4.0/dist/leaflet.js"
-   integrity="sha512-QVftwZFqvtRNi0ZyCtsznlKSWOStnDORoefr1enyq5mVL4tmKB3S/EnC3rRJcxCPavG10IcrVGSmPh6Qw5lwrg=="
-   crossorigin=""></script>
+<script src="js/stats.js"></script>
 
-   <script src="/js/distritos.js"></script>
+<script src="https://unpkg.com/leaflet@1.4.0/dist/leaflet.js" integrity="sha512-QVftwZFqvtRNi0ZyCtsznlKSWOStnDORoefr1enyq5mVL4tmKB3S/EnC3rRJcxCPavG10IcrVGSmPh6Qw5lwrg==" crossorigin=""></script>
+
+<script src="/js/distritos.js"></script>
 
 
 @endpush


### PR DESCRIPTION
First (line) graph was infinitely calculating the height until the browser froze and crashed. 

Fixed by moving height properties to a container on stats.blade.php:71

Styling properties actually shouldn't be on ChartJS <canvas> elements at all, only on parents, for multiple reasons (mentioned here https://www.chartjs.org/docs/latest/configuration/responsive.html), but don't seem to break anything else. 