### PR TITLE
Standardize the margin of Leaflet map controls

### DIFF
--- a/fogospt/resources/assets/sass/app.scss
+++ b/fogospt/resources/assets/sass/app.scss
@@ -1036,3 +1036,9 @@ deve ser carregado depois do CSS da leaflet */
       margin-top: 90px !important;
   }
 }
+
+/* Remove a `margin-bottom` aplicada pelo Bootstrap para garantir que os
+controls do Leaflet têm margens uniformes. */
+.leaflet-control-layers label:last-child {
+  margin-bottom: unset;
+}

--- a/fogospt/resources/assets/sass/app.scss
+++ b/fogospt/resources/assets/sass/app.scss
@@ -1037,8 +1037,8 @@ deve ser carregado depois do CSS da leaflet */
   }
 }
 
-/* Remove a `margin-bottom` aplicada pelo Bootstrap para garantir que os
-controls do Leaflet têm margens uniformes. */
+/* Remove a `margin-bottom` aplicada pelo Bootstrap para garantir que os widgets
+têm margens uniformes. */
 .leaflet-control-layers label:last-child {
   margin-bottom: unset;
 }


### PR DESCRIPTION
Hi! 👋 

Here is my proposal to standardize the margins. I chose that CSS selector because Leaflet also applies styles to style `label`s using that selector.

One question: should I commit the CSS and JS files generated in the `public/` folder or just the Sass file with the necessary changes?

Thanks!

## Demo

<img width="1582" alt="image" src="https://github.com/user-attachments/assets/c589ed65-5a86-4b71-8322-bb4a5f3c6133">

## Local commands

Some commands to use as an alternative to those documented in the README file to have a local environment with Python 2 (to install the necessary [node-gyp](https://github.com/nodejs/node-gyp/tree/v3.8.0?tab=readme-ov-file#on-macos) version) and Node.js 14 (and without the need to install a local version of PHP 7 + Composer):

```bash
fnm use 14
```

```bash
pyenv local 2 && pyenv install
```

```bash
docker run --rm -it -v "$(pwd):/app" composer:1.10.19 install
```