### PR TITLE
Add text wrap to “informação extra”

### DIFF
--- a/fogospt/resources/assets/sass/app.scss
+++ b/fogospt/resources/assets/sass/app.scss
@@ -1042,3 +1042,7 @@ têm margens uniformes. */
 .leaflet-control-layers label:last-child {
   margin-bottom: unset;
 }
+
+.f-extra {
+  text-wrap: wrap;
+}


### PR DESCRIPTION
This will allow text in “Informação extras” to wrap and avoid horizontal scrolling both on mobile and desktop sidebar


(Still not tested the changes)