### PR TITLE
Increase history chart height

### DIFF
--- a/fogospt/resources/views/elements/cards/resources.blade.php
+++ b/fogospt/resources/views/elements/cards/resources.blade.php
@@ -23,7 +23,7 @@
                         @endisset
                     </span>
                 </div>
-                <canvas class="px-2 py-0" id="myChart" width="400" height="150"></canvas>
+                <canvas class="px-2 py-0" id="myChart" width="400" height="350"></canvas>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Make a fire's history chart a bit more readable:

**Before:**
<img width="300" alt="imagem" src="https://github.com/user-attachments/assets/d7e6ea48-8c8c-4d02-8720-394764e03b28" />

**After:**
<img width="300" alt="imagem" src="https://github.com/user-attachments/assets/e796be18-4317-452c-a044-e7387c235fb5" />
