### PR TITLE
Prevent multiple charts from being created

### DIFF
--- a/fogospt/public/js/main.js
+++ b/fogospt/public/js/main.js
@@ -577,6 +577,8 @@ function addMaker(item, mymap) {
 
 }
 
+let detailsChart
+
 function plot(id) {
     var url = 'https://api-dev.fogos.pt/fires/data?id=' + id
     $.ajax({
@@ -596,7 +598,11 @@ function plot(id) {
                 }
 
                 var ctx = document.getElementById('myChart')
-                var myLineChart = new Chart(ctx, {
+
+                if(detailsChart)
+                    detailsChart.destroy()
+
+                detailsChart = new Chart(ctx, {
                     type: 'line',
                     data: {
                         labels: labels,


### PR DESCRIPTION
Currently a new chart is being created every time details for a fire are opened, while the previous one isn't cleared correctly. This causes them to overlap each other, like this:

https://github.com/user-attachments/assets/c6ff23ae-afd4-49cf-a29f-f4a6903b1d6c

<img width="400" alt="imagem" src="https://github.com/user-attachments/assets/050abc7d-5280-412c-af94-80fd7cb66f73" />

The chart is now stored in a variable, which is now cleared every time a new one is created.