### PR TITLE
i18n API docs/terms and refactor terms view

### DIFF
--- a/fogospt/app/Http/Controllers/GenericController.php
+++ b/fogospt/app/Http/Controllers/GenericController.php
@@ -118,14 +118,14 @@ class GenericController extends Controller
 
     public function api()
     {
-        $this->setPageName('Acesso à API do Fogos.pt');
+        $this->setPageName(__('api-docs.meta_title'));
 
         return view('api')->with(['metadata' => $this->generateMetadata()]);
     }
 
     public function apiTerms()
     {
-        $this->setPageName('Acesso à API do Fogos.pt');
+        $this->setPageName(__('api-terms.meta_title'));
 
         return view('api-terms')->with(['metadata' => $this->generateMetadata()]);
     }

--- a/fogospt/resources/lang/en/api-docs.php
+++ b/fogospt/resources/lang/en/api-docs.php
@@ -1,0 +1,87 @@
+<?php
+
+return [
+    'meta_title' => 'Fogos.pt API access',
+
+    'title' => 'Fogos.pt API access — New rules and usage controls',
+
+    'intro_lead' => 'Over the years, Fogos.pt has provided a public API widely used by many organisations and projects.',
+
+    'intro_p2_before' => 'That openness has always been intentional and aligned with the project principles:',
+    'intro_p2_strong' => 'open data, transparency and public utility',
+    'intro_p2_after' => '.',
+
+    'intro_p3_before' => 'However, significant growth in API usage — often without identification or controls — has created challenges for',
+    'intro_p3_strong' => 'performance, stability and availability',
+    'intro_p3_after' => '.',
+
+    'intro_p4' => 'Cases of abusive use that consume resources disproportionately have also been identified.',
+
+    'why_title' => 'Why is this changing now?',
+
+    'why_p1_before' => 'Fogos.pt\'s main goal remains:',
+    'why_p1_strong' => 'to provide reliable, up-to-date information that is accessible to all citizens',
+    'why_p1_after' => '.',
+
+    'why_p2' => 'To achieve that, it is essential to ensure infrastructure is not compromised by uncontrolled access.',
+
+    'why_p3' => 'These changes aim to ensure everyone can keep using the service in a stable and sustainable way.',
+
+    'change_title' => 'What will change?',
+
+    'change_alert_before' => '',
+    'change_alert_strong' => 'Soon',
+    'change_alert_after' => ', API access will be restricted to authorised users.',
+
+    'change_intro' => 'All API requests must meet the following:',
+
+    'req_auth_intro' => 'Mandatory authentication via header:',
+    'req_auth_pre' => 'FOGOS-PT-AUTH: {token}',
+
+    'req_token' => 'Use of an <strong>individual token</strong>',
+    'req_user_agent' => 'An identifiable and specific <strong>User-Agent</strong>',
+    'req_ip' => 'Indication of the <strong>source IP</strong> whenever possible',
+
+    'change_danger' => 'Requests that do not meet these requirements may be limited or blocked.',
+
+    'access_title' => 'How do I get access?',
+
+    'access_p1' => 'API access will depend on a formal request.',
+
+    'access_p2' => 'To request authorisation, please complete the form:',
+
+    'form_label' => 'Application form',
+    'form_url' => 'https://forms.gle/TH1REx1nEm9MnJVM9',
+
+    'review_intro' => 'Each request will be assessed based on:',
+
+    'review_criteria' => [
+        'Intended use',
+        'Request volume',
+        'Impact on infrastructure',
+        'Alignment with the project\'s goals',
+    ],
+
+    'principles_title' => 'Principles of use',
+
+    'principles' => [
+        'Do not compromise <strong>service availability</strong>',
+        'Avoid excessive or unnecessary load',
+        'Ensure requests are clearly identifiable',
+        'Responsible and ethical use of data',
+    ],
+
+    'community_title' => 'A commitment to the community',
+
+    'community_p1_before' => 'Fogos.pt will remain a project that is',
+    'community_p1_strong' => 'open, transparent and in service of society',
+    'community_p1_after' => '.',
+
+    'community_p2_before' => 'These measures are necessary so the platform can keep serving',
+    'community_p2_strong' => 'millions of users every year',
+    'community_p2_after' => ', especially at critical moments.',
+
+    'community_p3_before' => 'We count on everyone\'s cooperation to keep this service',
+    'community_p3_strong' => 'reliable, stable and sustainable',
+    'community_p3_after' => '.',
+];

--- a/fogospt/resources/lang/en/api-terms.php
+++ b/fogospt/resources/lang/en/api-terms.php
@@ -1,0 +1,141 @@
+<?php
+
+return [
+    'meta_title' => 'Fogos.pt API terms of use',
+
+    'title' => 'Fogos.pt API terms of use',
+
+    'intro_alert' => 'Use of the Fogos.pt API implies full reading, understanding and acceptance of these terms of use.',
+
+    'sections' => [
+        [
+            'title' => '1. Scope',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'The Fogos.pt API is provided as part of a public-interest project aimed at promoting access to wildfire-related information in a transparent, open and accessible way.'],
+                ['type' => 'p', 'html' => 'Fogos.pt reserves the right to define rules on access, authentication, technical controls and usage limits whenever necessary to protect the stability, availability and sustainability of the platform.'],
+            ],
+        ],
+        [
+            'title' => '2. Permitted use',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Use of the API is permitted in the following contexts:'],
+                ['type' => 'ul', 'items' => [
+                    ['html' => '<strong>Personal use</strong>, including individual, academic, educational, research or experimental projects'],
+                    ['html' => '<strong>Use by organisations, including companies, for non-commercial purposes</strong>, including:', 'subitems' => [
+                        'Research',
+                        'Data analysis',
+                        'Internal operational support tools',
+                        'Civic or public-interest projects',
+                        'Internal monitoring or visualisation without commercial exploitation',
+                    ]],
+                ]],
+                ['type' => 'p', 'html' => 'Permission to use the API depends, where applicable, on prior authorisation and the allocation of valid access credentials.'],
+            ],
+        ],
+        [
+            'title' => '3. Prohibited use',
+            'blocks' => [
+                ['type' => 'alert_danger', 'html' => 'Use of the API is not permitted in contexts involving monetisation, commercial promotion or direct or indirect economic exploitation.'],
+                ['type' => 'ul', 'items' => [
+                    ['html' => 'On platforms, applications, websites or services that include:', 'subitems' => [
+                        '<strong>Advertising</strong>, including banners, ads, sponsorships, programmatic monetisation or sponsored content',
+                        '<strong>Collection of donations, contributions, crowdfunding or other forms of fundraising</strong>',
+                    ]],
+                    ['html' => 'In paid services, subscription services or any paid arrangement'],
+                    ['html' => 'In products or services marketed to third parties'],
+                    ['html' => 'In solutions whose value or business model depends, wholly or partly, on making API data available'],
+                    ['html' => 'Resale, commercial redistribution or sublicensing of data obtained through the API'],
+                    ['html' => 'Any use that could compromise Fogos.pt’s <strong>availability, performance, security or stability</strong>'],
+                    ['html' => 'Any use that omits or seeks to conceal the origin of the data'],
+                    ['html' => 'Any use that circumvents authentication, limits, authorisation or control mechanisms defined by Fogos.pt'],
+                ]],
+            ],
+        ],
+        [
+            'title' => '4. Credit and attribution',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'All use of the API must include <strong>a clear, visible and unambiguous reference to the source of the data</strong>.'],
+                ['type' => 'alert_light', 'html' => '<strong>Source: Fogos.pt</strong>'],
+                ['type' => 'p', 'html' => 'Whenever possible, a link to the official website should also be included: <a href="https://fogos.pt" target="_blank" rel="noopener noreferrer">https://fogos.pt</a>'],
+                ['type' => 'p', 'html' => 'Attribution must be clearly visible to end users alongside data, maps, charts, dashboards or any other element that uses information from the API.'],
+                ['type' => 'alert_warning', 'html' => 'Missing attribution, insufficient attribution or concealing the origin of the data constitutes a breach of these terms.'],
+            ],
+        ],
+        [
+            'title' => '5. Technical rules of use',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'API users agree to:'],
+                ['type' => 'ul', 'items' => [
+                    ['html' => 'Use only the authentication mechanisms provided, including access tokens when required'],
+                    ['html' => 'Send requests with the authentication header defined by Fogos.pt'],
+                    ['html' => 'Include an identifiable <strong>User-Agent</strong> and, whenever possible, one specific to the application or service'],
+                    ['html' => 'Indicate, whenever possible, the IP address or technical origin of requests'],
+                    ['html' => 'Avoid excessive, bulk or unnecessarily abusive automated requests'],
+                    ['html' => 'Respect usage limits, rate limits, quotas or other technical restrictions that may be defined'],
+                    ['html' => 'Not attempt to circumvent blocks, restrictions, monitoring mechanisms or protective measures'],
+                    ['html' => 'Follow good technical practices that reduce the impact of API usage on Fogos.pt infrastructure'],
+                ]],
+            ],
+        ],
+        [
+            'title' => '6. Service availability',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Fogos.pt does not guarantee that the API will be permanently available, uninterrupted, fault-free, complete or up to date at all times.'],
+                ['type' => 'p', 'html' => 'API access may be conditioned, limited, suspended or interrupted, in whole or in part, for technical or operational reasons, security, maintenance, infrastructure protection, architecture changes or resource management.'],
+                ['type' => 'p', 'html' => 'Fogos.pt may also change endpoints, response structures, authentication methods, usage limits or other technical conditions without prior notice.'],
+            ],
+        ],
+        [
+            'title' => '7. Accuracy and quality of data',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Although Fogos.pt strives to provide useful, up-to-date and reliable information, <strong>no express or implied warranty is given</strong> as to accuracy, completeness, timeliness, consistency, availability or fitness of the data for any particular purpose.'],
+                ['type' => 'p', 'html' => 'Data provided through the API may depend on external sources, automated processes, technical integrations and update pipelines subject to failures, delays, omissions, inconsistencies or interruptions.'],
+                ['type' => 'p', 'html' => 'It is solely the user’s responsibility to assess whether the data is suitable for the intended context.'],
+            ],
+        ],
+        [
+            'title' => '8. Limitation of liability',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Fogos.pt, its representatives, collaborators or associated entities shall not be liable for any direct, indirect, incidental, consequential, special or other damages arising from use, inability to use or reliance on information provided through the API.'],
+                ['type' => 'p', 'html' => 'This includes, without limitation, data loss, operational loss, reputational harm, decision failures, business interruption, economic loss or any consequences arising from errors, omissions, unavailability, delays or inaccuracies in the data.'],
+            ],
+        ],
+        [
+            'title' => '9. Critical or sensitive uses',
+            'blocks' => [
+                ['type' => 'alert_danger', 'html' => 'The Fogos.pt API must not be used as the sole or decisive source in critical contexts, emergencies, security, civil protection or sensitive operational decision-making.'],
+                ['type' => 'p', 'html' => 'Use of the API in alerting systems, dispatch, operational coordination, emergency response, protection of people and property, or any other context where errors, delays or unavailability could cause harm must always be accompanied by independent validation and complementary sources.'],
+                ['type' => 'p', 'html' => 'The user accepts full responsibility for any use of the API in high-risk or critical decision-making contexts.'],
+            ],
+        ],
+        [
+            'title' => '10. Suspension, revocation and blocking of access',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Fogos.pt reserves the right, at any time and without prior notice, to:'],
+                ['type' => 'ul', 'items' => [
+                    ['html' => 'Limit, suspend or revoke authorised access'],
+                    ['html' => 'Deactivate assigned tokens or credentials'],
+                    ['html' => 'Block requests, origins, applications or users'],
+                    ['html' => 'Refuse new access requests'],
+                    ['html' => 'Implement additional technical control, filtering or protection measures'],
+                ]],
+                ['type' => 'p', 'html' => 'Such measures may be taken, among other reasons, in case of breach of these terms, abusive use, technical risk, legal risk, negative impact on the service or need to protect platform users.'],
+            ],
+        ],
+        [
+            'title' => '11. Changes to the terms',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Fogos.pt may change these terms of use at any time without prior notice.'],
+                ['type' => 'p', 'html' => 'Users are responsible for reviewing this page periodically and ensuring they comply with the latest applicable terms.'],
+            ],
+        ],
+        [
+            'title' => '13. Final remarks',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'The Fogos.pt API exists to serve the community and support access to public-interest information.'],
+                ['type' => 'p', 'html' => 'Its use must respect the spirit of the project: <strong>public service, responsibility, transparency and sustainability</strong>.'],
+                ['type' => 'p', 'html' => 'Continuity of this service depends on responsible, identifiable use aligned with the platform’s core mission: keeping Fogos.pt online, updated and stable for all citizens.'],
+            ],
+        ],
+    ],
+];

--- a/fogospt/resources/lang/es/api-docs.php
+++ b/fogospt/resources/lang/es/api-docs.php
@@ -1,0 +1,87 @@
+<?php
+
+return [
+    'meta_title' => 'Acceso a la API de Fogos.pt',
+
+    'title' => 'Acceso a la API de Fogos.pt — Nuevas reglas y control de uso',
+
+    'intro_lead' => 'Fogos.pt ha puesto durante años a disposición una API pública ampliamente utilizada por diversas entidades y proyectos.',
+
+    'intro_p2_before' => 'Esa apertura ha sido siempre intencional y alineada con los principios del proyecto:',
+    'intro_p2_strong' => 'datos abiertos, transparencia y utilidad pública',
+    'intro_p2_after' => '.',
+
+    'intro_p3_before' => 'Sin embargo, el crecimiento significativo del uso de la API — a menudo sin identificación ni control — está generando retos en términos de',
+    'intro_p3_strong' => 'rendimiento, estabilidad y disponibilidad',
+    'intro_p3_after' => '.',
+
+    'intro_p4' => 'También se han identificado usos abusivos que consumen recursos de forma desproporcionada.',
+
+    'why_title' => '¿Por qué cambia ahora?',
+
+    'why_p1_before' => 'El objetivo principal de Fogos.pt se mantiene:',
+    'why_p1_strong' => 'garantizar información fiable, actualizada y accesible para todos los ciudadanos',
+    'why_p1_after' => '.',
+
+    'why_p2' => 'Para ello es esencial asegurar que la infraestructura no se vea comprometida por accesos descontrolados.',
+
+    'why_p3' => 'Estos cambios pretenden garantizar que todos puedan seguir usando el servicio de forma estable y sostenible.',
+
+    'change_title' => '¿Qué va a cambiar?',
+
+    'change_alert_before' => '',
+    'change_alert_strong' => 'En breve',
+    'change_alert_after' => ', el acceso a la API quedará restringido a usuarios autorizados.',
+
+    'change_intro' => 'Todas las peticiones a la API deberán cumplir:',
+
+    'req_auth_intro' => 'Autenticación obligatoria mediante cabecera:',
+    'req_auth_pre' => 'FOGOS-PT-AUTH: {token}',
+
+    'req_token' => 'Uso de un <strong>token individual</strong>',
+    'req_user_agent' => '<strong>User-Agent</strong> identificable y específico',
+    'req_ip' => 'Indicación de la <strong>IP de origen</strong>, siempre que sea posible',
+
+    'change_danger' => 'Las peticiones que no cumplan estos requisitos podrán ser limitadas o bloqueadas.',
+
+    'access_title' => '¿Cómo obtener acceso?',
+
+    'access_p1' => 'El acceso a la API dependerá de una solicitud formal.',
+
+    'access_p2' => 'Para solicitar autorización, debe cumplimentar el formulario:',
+
+    'form_label' => 'Formulario',
+    'form_url' => 'https://forms.gle/TH1REx1nEm9MnJVM9',
+
+    'review_intro' => 'Cada solicitud se analizará en función de:',
+
+    'review_criteria' => [
+        'Finalidad del uso',
+        'Volumen de peticiones',
+        'Impacto en la infraestructura',
+        'Alineación con los objetivos del proyecto',
+    ],
+
+    'principles_title' => 'Principios de uso',
+
+    'principles' => [
+        'No comprometer la <strong>disponibilidad del servicio</strong>',
+        'Evitar cargas excesivas o innecesarias',
+        'Garantizar una identificación clara de las peticiones',
+        'Uso responsable y ético de los datos',
+    ],
+
+    'community_title' => 'Un compromiso con la comunidad',
+
+    'community_p1_before' => 'Fogos.pt seguirá siendo un proyecto',
+    'community_p1_strong' => 'abierto, transparente y al servicio de la sociedad',
+    'community_p1_after' => '.',
+
+    'community_p2_before' => 'Estas medidas son necesarias para garantizar que la plataforma siga sirviendo a',
+    'community_p2_strong' => 'millones de usuarios cada año',
+    'community_p2_after' => ', especialmente en momentos críticos.',
+
+    'community_p3_before' => 'Contamos con la colaboración de todos para mantener este servicio',
+    'community_p3_strong' => 'fiable, estable y sostenible',
+    'community_p3_after' => '.',
+];

--- a/fogospt/resources/lang/es/api-terms.php
+++ b/fogospt/resources/lang/es/api-terms.php
@@ -1,0 +1,141 @@
+<?php
+
+return [
+    'meta_title' => 'Términos de uso de la API de Fogos.pt',
+
+    'title' => 'Términos de uso de la API de Fogos.pt',
+
+    'intro_alert' => 'El uso de la API de Fogos.pt implica la lectura, comprensión y aceptación íntegra de los presentes términos de uso.',
+
+    'sections' => [
+        [
+            'title' => '1. Ámbito',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'La API de Fogos.pt se ofrece en el marco de un proyecto de interés público, con el objetivo de promover el acceso a información sobre incendios de forma transparente, abierta y accesible.'],
+                ['type' => 'p', 'html' => 'Fogos.pt se reserva el derecho de definir normas de acceso, autenticación, control técnico y limitación de uso cuando sea necesario para proteger la estabilidad, la disponibilidad y la sostenibilidad de la plataforma.'],
+            ],
+        ],
+        [
+            'title' => '2. Uso permitido',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Está permitido el uso de la API en los siguientes contextos:'],
+                ['type' => 'ul', 'items' => [
+                    ['html' => '<strong>Uso personal</strong>, incluidos proyectos individuales, académicos, educativos, de investigación o experimentales'],
+                    ['html' => '<strong>Uso por entidades, incluidas empresas, con fines no comerciales</strong>, en particular:', 'subitems' => [
+                        'Investigación',
+                        'Análisis de datos',
+                        'Herramientas internas de apoyo operativo',
+                        'Proyectos cívicos o de interés público',
+                        'Monitorización o visualización interna sin explotación comercial',
+                    ]],
+                ]],
+                ['type' => 'p', 'html' => 'El permiso de uso depende, cuando corresponda, de la obtención de autorización previa y de la asignación de credenciales de acceso válidas.'],
+            ],
+        ],
+        [
+            'title' => '3. Uso no permitido',
+            'blocks' => [
+                ['type' => 'alert_danger', 'html' => 'No está permitido el uso de la API en contextos de monetización, promoción comercial o explotación económica directa o indirecta.'],
+                ['type' => 'ul', 'items' => [
+                    ['html' => 'En plataformas, aplicaciones, sitios web o servicios que incluyan:', 'subitems' => [
+                        '<strong>Publicidad</strong>, incluidos banners, anuncios, patrocinios, monetización programática o contenidos patrocinados',
+                        '<strong>Recaudación de donaciones, contribuciones, crowdfunding u otras formas de financiación</strong>',
+                    ]],
+                    ['html' => 'En servicios de pago, por suscripción o con cualquier contraprestación económica'],
+                    ['html' => 'En productos o servicios comercializados a terceros'],
+                    ['html' => 'En soluciones cuyo valor o modelo de negocio dependa, total o parcialmente, de la puesta a disposición de los datos de la API'],
+                    ['html' => 'En la reventa, redistribución comercial o sublicencia de los datos obtenidos a través de la API'],
+                    ['html' => 'En cualquier uso que pueda comprometer la <strong>disponibilidad, el rendimiento, la seguridad o la estabilidad</strong> de Fogos.pt'],
+                    ['html' => 'En cualquier uso que omita u oculte el origen de los datos'],
+                    ['html' => 'En cualquier uso que eluda mecanismos de autenticación, limitación, autorización o control definidos por Fogos.pt'],
+                ]],
+            ],
+        ],
+        [
+            'title' => '4. Créditos y atribución',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Todo uso de la API debe incluir <strong>una referencia clara, visible e inequívoca al origen de los datos</strong>.'],
+                ['type' => 'alert_light', 'html' => '<strong>Fuente: Fogos.pt</strong>'],
+                ['type' => 'p', 'html' => 'Siempre que sea posible, también debe incluirse un enlace al sitio oficial: <a href="https://fogos.pt" target="_blank" rel="noopener noreferrer">https://fogos.pt</a>'],
+                ['type' => 'p', 'html' => 'La atribución debe mostrarse de forma visible al usuario final junto a los datos, mapas, gráficos, paneles o cualquier otro elemento que utilice información procedente de la API.'],
+                ['type' => 'alert_warning', 'html' => 'La ausencia de atribución, una atribución insuficiente u ocultar el origen de los datos constituye incumplimiento de los presentes términos.'],
+            ],
+        ],
+        [
+            'title' => '5. Normas técnicas de uso',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Los usuarios de la API se comprometen a:'],
+                ['type' => 'ul', 'items' => [
+                    ['html' => 'Utilizar exclusivamente los mecanismos de autenticación proporcionados, incluido el token de acceso cuando sea obligatorio'],
+                    ['html' => 'Enviar las peticiones con la cabecera de autenticación definida por Fogos.pt'],
+                    ['html' => 'Incluir un <strong>User-Agent identificable</strong> y, siempre que sea posible, específico de la aplicación o servicio'],
+                    ['html' => 'Indicar, siempre que sea posible, la IP u origen técnico de las peticiones'],
+                    ['html' => 'No realizar peticiones excesivas, masivas, automatizadas de forma abusiva o innecesaria'],
+                    ['html' => 'Respetar límites de uso, rate limits, cuotas u otras restricciones técnicas que puedan definirse'],
+                    ['html' => 'No intentar eludir bloqueos, restricciones, mecanismos de monitorización o medidas de protección'],
+                    ['html' => 'Adoptar buenas prácticas técnicas que reduzcan el impacto del uso de la API en la infraestructura de Fogos.pt'],
+                ]],
+            ],
+        ],
+        [
+            'title' => '6. Disponibilidad del servicio',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Fogos.pt no garantiza que la API esté permanentemente disponible, ininterrumpida, libre de fallos, completa o actualizada en todo momento.'],
+                ['type' => 'p', 'html' => 'El acceso a la API puede condicionarse, limitarse, suspenderse o interrumpirse, total o parcialmente, por motivos técnicos u operativos, de seguridad, mantenimiento, protección de la infraestructura, cambios de arquitectura o gestión de recursos.'],
+                ['type' => 'p', 'html' => 'Fogos.pt también puede modificar endpoints, estructuras de respuesta, métodos de autenticación, límites de uso u otras condiciones técnicas sin necesidad de aviso previo.'],
+            ],
+        ],
+        [
+            'title' => '7. Exactitud y calidad de los datos',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Aunque Fogos.pt procura ofrecer información útil, actualizada y fiable, <strong>no se ofrece garantía expresa ni implícita</strong> en cuanto a exactitud, integridad, vigencia, coherencia, disponibilidad o idoneidad de los datos para un fin determinado.'],
+                ['type' => 'p', 'html' => 'Los datos facilitados a través de la API pueden depender de fuentes externas, procesos automáticos, integraciones técnicas y flujos de actualización sujetos a fallos, retrasos, omisiones, incoherencias o interrupciones.'],
+                ['type' => 'p', 'html' => 'Corresponde exclusivamente al usuario evaluar la idoneidad de los datos en el contexto en que pretenda utilizarlos.'],
+            ],
+        ],
+        [
+            'title' => '8. Limitación de responsabilidad',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Fogos.pt, sus responsables, colaboradores o entidades asociadas no podrán ser responsabilizados por daños directos, indirectos, incidentales, consecuentes, especiales o de cualquier otra naturaleza derivados del uso, la imposibilidad de uso o la confianza depositada en la información facilitada a través de la API.'],
+                ['type' => 'p', 'html' => 'Esto incluye, sin limitación, pérdidas de datos, pérdidas operativas, daños reputacionales, errores de decisión, interrupciones de actividad, perjuicios económicos o cualquier consecuencia derivada de errores, omisiones, indisponibilidad, retrasos o inexactitudes en los datos.'],
+            ],
+        ],
+        [
+            'title' => '9. Usos críticos o sensibles',
+            'blocks' => [
+                ['type' => 'alert_danger', 'html' => 'La API de Fogos.pt no debe utilizarse como fuente única o determinante en contextos críticos, de emergencia, seguridad, protección civil o toma de decisiones operativas sensibles.'],
+                ['type' => 'p', 'html' => 'El uso de la API en sistemas de alerta, despacho, coordinación operativa, respuesta de emergencia, protección de personas y bienes, o cualquier otro contexto en el que errores, retrasos o indisponibilidades puedan causar daños debe ir siempre acompañado de validación independiente y fuentes complementarias.'],
+                ['type' => 'p', 'html' => 'El usuario asume íntegramente la responsabilidad por cualquier uso de la API en contextos de alto riesgo o decisión crítica.'],
+            ],
+        ],
+        [
+            'title' => '10. Suspensión, revocación y bloqueo de acceso',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Fogos.pt se reserva el derecho de, en cualquier momento y sin necesidad de aviso previo:'],
+                ['type' => 'ul', 'items' => [
+                    ['html' => 'Limitar, suspender o revocar accesos autorizados'],
+                    ['html' => 'Desactivar tokens o credenciales asignadas'],
+                    ['html' => 'Bloquear peticiones, orígenes, aplicaciones o usuarios'],
+                    ['html' => 'Rechazar nuevas solicitudes de acceso'],
+                    ['html' => 'Implementar medidas técnicas adicionales de control, filtrado o protección'],
+                ]],
+                ['type' => 'p', 'html' => 'Estas medidas podrán adoptarse, entre otros supuestos, en caso de incumplimiento de los presentes términos, uso abusivo, riesgo técnico, riesgo jurídico, impacto negativo en el servicio o necesidad de proteger a los usuarios de la plataforma.'],
+            ],
+        ],
+        [
+            'title' => '11. Cambios en los términos',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Fogos.pt puede modificar los presentes términos de uso en cualquier momento sin aviso previo.'],
+                ['type' => 'p', 'html' => 'Es responsabilidad de los usuarios consultar periódicamente esta página y asegurarse de cumplir la versión más reciente de los términos aplicables.'],
+            ],
+        ],
+        [
+            'title' => '13. Consideraciones finales',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'La API de Fogos.pt existe para servir a la comunidad y apoyar el acceso a información de interés público.'],
+                ['type' => 'p', 'html' => 'Su uso debe respetar el espíritu del proyecto: <strong>servicio público, responsabilidad, transparencia y sostenibilidad</strong>.'],
+                ['type' => 'p', 'html' => 'La continuidad de este servicio depende de un uso responsable, identificado y compatible con la misión principal de la plataforma: mantener Fogos.pt en línea, actualizado y estable para todos los ciudadanos.'],
+            ],
+        ],
+    ],
+];

--- a/fogospt/resources/lang/pt/api-docs.php
+++ b/fogospt/resources/lang/pt/api-docs.php
@@ -1,0 +1,87 @@
+<?php
+
+return [
+    'meta_title' => 'Acesso à API do Fogos.pt',
+
+    'title' => 'Acesso à API do Fogos.pt — Novas Regras e Controlo de Utilização',
+
+    'intro_lead' => 'O Fogos.pt tem, ao longo dos anos, disponibilizado uma API pública amplamente utilizada por diversas entidades e projetos.',
+
+    'intro_p2_before' => 'Essa abertura foi sempre intencional e alinhada com os princípios do projeto:',
+    'intro_p2_strong' => 'dados abertos, transparência e utilidade pública',
+    'intro_p2_after' => '.',
+
+    'intro_p3_before' => 'No entanto, o crescimento significativo da utilização da API — muitas vezes sem qualquer identificação ou controlo — tem vindo a criar desafios ao nível da',
+    'intro_p3_strong' => 'performance, estabilidade e disponibilidade',
+    'intro_p3_after' => '.',
+
+    'intro_p4' => 'Foram também identificadas situações de utilização abusiva, que consomem recursos de forma desproporcional.',
+
+    'why_title' => 'Porque é que isto muda agora?',
+
+    'why_p1_before' => 'O objetivo principal do Fogos.pt mantém-se:',
+    'why_p1_strong' => 'garantir informação fiável, atualizada e acessível a todos os cidadãos',
+    'why_p1_after' => '.',
+
+    'why_p2' => 'Para isso, é essencial assegurar que a infraestrutura não é comprometida por acessos descontrolados.',
+
+    'why_p3' => 'Estas alterações pretendem garantir que todos conseguem continuar a usar o serviço de forma estável e sustentável.',
+
+    'change_title' => 'O que vai mudar?',
+
+    'change_alert_before' => '',
+    'change_alert_strong' => 'Brevemente',
+    'change_alert_after' => ', o acesso à API passará a estar restrito a utilizadores autorizados.',
+
+    'change_intro' => 'Todos os pedidos à API deverão cumprir:',
+
+    'req_auth_intro' => 'Autenticação obrigatória via header:',
+    'req_auth_pre' => 'FOGOS-PT-AUTH: {token}',
+
+    'req_token' => 'Utilização de <strong>token individual</strong>',
+    'req_user_agent' => 'User-Agent <strong>identificável e personalizado</strong>',
+    'req_ip' => 'Indicação do <strong>IP de origem</strong>, sempre que possível',
+
+    'change_danger' => 'Pedidos que não cumpram estes requisitos poderão ser limitados ou bloqueados.',
+
+    'access_title' => 'Como obter acesso?',
+
+    'access_p1' => 'O acesso à API passará a depender de um pedido formal.',
+
+    'access_p2' => 'Para solicitar autorização, deverá preencher o formulário:',
+
+    'form_label' => 'Formulário',
+    'form_url' => 'https://forms.gle/TH1REx1nEm9MnJVM9',
+
+    'review_intro' => 'Cada pedido será analisado com base em:',
+
+    'review_criteria' => [
+        'Finalidade de utilização',
+        'Volume de pedidos',
+        'Impacto na infraestrutura',
+        'Alinhamento com os objetivos do projeto',
+    ],
+
+    'principles_title' => 'Princípios de utilização',
+
+    'principles' => [
+        'Não comprometer a <strong>disponibilidade do serviço</strong>',
+        'Evitar cargas excessivas ou desnecessárias',
+        'Garantir identificação clara dos pedidos',
+        'Utilização responsável e ética dos dados',
+    ],
+
+    'community_title' => 'Um compromisso com a comunidade',
+
+    'community_p1_before' => 'O Fogos.pt continuará a ser um projeto',
+    'community_p1_strong' => 'aberto, transparente e ao serviço da sociedade',
+    'community_p1_after' => '.',
+
+    'community_p2_before' => 'Estas medidas são necessárias para garantir que a plataforma continua a servir',
+    'community_p2_strong' => 'milhões de utilizadores todos os anos',
+    'community_p2_after' => ', especialmente em momentos críticos.',
+
+    'community_p3_before' => 'Contamos com a colaboração de todos para manter este serviço',
+    'community_p3_strong' => 'fiável, estável e sustentável',
+    'community_p3_after' => '.',
+];

--- a/fogospt/resources/lang/pt/api-terms.php
+++ b/fogospt/resources/lang/pt/api-terms.php
@@ -1,0 +1,141 @@
+<?php
+
+return [
+    'meta_title' => 'Termos de Utilização da API do Fogos.pt',
+
+    'title' => 'Termos de Utilização da API do Fogos.pt',
+
+    'intro_alert' => 'A utilização da API do Fogos.pt implica a leitura, compreensão e aceitação integral dos presentes termos de utilização.',
+
+    'sections' => [
+        [
+            'title' => '1. Âmbito',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'A API do Fogos.pt é disponibilizada no âmbito de um projeto de interesse público, com o objetivo de promover o acesso a informação sobre incêndios de forma transparente, aberta e acessível.'],
+                ['type' => 'p', 'html' => 'O Fogos.pt reserva-se o direito de definir regras de acesso, autenticação, controlo técnico e limitação de utilização, sempre que tal seja necessário para proteger a estabilidade, a disponibilidade e a sustentabilidade da plataforma.'],
+            ],
+        ],
+        [
+            'title' => '2. Utilização Permitida',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'É permitida a utilização da API nos seguintes contextos:'],
+                ['type' => 'ul', 'items' => [
+                    ['html' => '<strong>Utilização pessoal</strong>, incluindo projetos individuais, académicos, educativos, de investigação ou experimentais'],
+                    ['html' => '<strong>Utilização por entidades, incluindo empresas, para fins não comerciais</strong>, nomeadamente:', 'subitems' => [
+                        'Investigação',
+                        'Análise de dados',
+                        'Ferramentas internas de apoio operacional',
+                        'Projetos cívicos ou de interesse público',
+                        'Monitorização ou visualização interna sem exploração comercial',
+                    ]],
+                ]],
+                ['type' => 'p', 'html' => 'A permissão de utilização depende, quando aplicável, da obtenção de autorização prévia e da atribuição de credenciais de acesso válidas.'],
+            ],
+        ],
+        [
+            'title' => '3. Utilização Não Permitida',
+            'blocks' => [
+                ['type' => 'alert_danger', 'html' => 'Não é permitida a utilização da API em contextos de monetização, promoção comercial ou exploração económica direta ou indireta.'],
+                ['type' => 'ul', 'items' => [
+                    ['html' => 'Em plataformas, aplicações, websites ou serviços que incluam:', 'subitems' => [
+                        '<strong>Publicidade</strong>, incluindo banners, anúncios, patrocínios, monetização programática ou conteúdos patrocinados',
+                        '<strong>Recolha de donativos, contribuições, crowdfunding ou outras formas de financiamento</strong>',
+                    ]],
+                    ['html' => 'Em serviços pagos, por subscrição ou mediante qualquer contrapartida económica'],
+                    ['html' => 'Em produtos ou serviços comercializados a terceiros'],
+                    ['html' => 'Em soluções cujo valor ou modelo de negócio dependa, total ou parcialmente, da disponibilização dos dados da API'],
+                    ['html' => 'Na revenda, redistribuição comercial ou sublicenciamento dos dados obtidos através da API'],
+                    ['html' => 'Em qualquer utilização que possa comprometer a <strong>disponibilidade, desempenho, segurança ou estabilidade</strong> do Fogos.pt'],
+                    ['html' => 'Em qualquer utilização que omita ou procure ocultar a origem dos dados'],
+                    ['html' => 'Em qualquer utilização que contorne mecanismos de autenticação, limitação, autorização ou controlo definidos pelo Fogos.pt'],
+                ]],
+            ],
+        ],
+        [
+            'title' => '4. Créditos e Atribuição',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Toda a utilização da API deve incluir <strong>referência clara, visível e inequívoca à origem dos dados</strong>.'],
+                ['type' => 'alert_light', 'html' => '<strong>Fonte: Fogos.pt</strong>'],
+                ['type' => 'p', 'html' => 'Sempre que possível, deverá igualmente ser incluído um link para o site oficial: <a href="https://fogos.pt" target="_blank" rel="noopener noreferrer">https://fogos.pt</a>'],
+                ['type' => 'p', 'html' => 'A atribuição deve estar colocada de forma visível ao utilizador final, junto aos dados, mapas, gráficos, dashboards ou qualquer outro elemento que utilize informação proveniente da API.'],
+                ['type' => 'alert_warning', 'html' => 'A ausência de atribuição, a atribuição insuficiente ou a ocultação da origem dos dados constitui incumprimento dos presentes termos.'],
+            ],
+        ],
+        [
+            'title' => '5. Regras Técnicas de Utilização',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Os utilizadores da API comprometem-se a:'],
+                ['type' => 'ul', 'items' => [
+                    ['html' => 'Utilizar exclusivamente os mecanismos de autenticação fornecidos, incluindo token de acesso quando exigido'],
+                    ['html' => 'Enviar os pedidos com o header de autenticação definido pelo Fogos.pt'],
+                    ['html' => 'Incluir um <strong>User-Agent identificável</strong> e, sempre que possível, específico da aplicação ou serviço em causa'],
+                    ['html' => 'Indicar, sempre que possível, o IP ou origem técnica dos pedidos'],
+                    ['html' => 'Não efetuar pedidos excessivos, massivos, automatizados de forma abusiva ou desnecessária'],
+                    ['html' => 'Respeitar limites de utilização, rate limits, quotas ou outras restrições técnicas que venham a ser definidas'],
+                    ['html' => 'Não tentar contornar bloqueios, restrições, mecanismos de monitorização ou medidas de proteção'],
+                    ['html' => 'Adotar boas práticas técnicas que reduzam o impacto da utilização da API na infraestrutura do Fogos.pt'],
+                ]],
+            ],
+        ],
+        [
+            'title' => '6. Disponibilidade do Serviço',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'O Fogos.pt não garante que a API esteja permanentemente disponível, ininterrupta, livre de falhas, completa ou atualizada em todos os momentos.'],
+                ['type' => 'p', 'html' => 'O acesso à API poderá ser condicionado, limitado, suspenso ou interrompido, total ou parcialmente, por motivos técnicos, operacionais, de segurança, manutenção, proteção da infraestrutura, alteração de arquitetura ou gestão de recursos.'],
+                ['type' => 'p', 'html' => 'O Fogos.pt poderá ainda alterar endpoints, estruturas de resposta, métodos de autenticação, limites de utilização ou outras condições técnicas sem necessidade de aviso prévio.'],
+            ],
+        ],
+        [
+            'title' => '7. Exatidão e Qualidade dos Dados',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'Embora o Fogos.pt procure disponibilizar informação útil, atualizada e fiável, <strong>não é prestada qualquer garantia expressa ou implícita</strong> quanto à exatidão, integridade, atualidade, consistência, disponibilidade ou adequação dos dados a qualquer finalidade específica.'],
+                ['type' => 'p', 'html' => 'Os dados disponibilizados através da API podem depender de fontes externas, processos automáticos, integrações técnicas e fluxos de atualização que estão sujeitos a falhas, atrasos, omissões, inconsistências ou interrupções.'],
+                ['type' => 'p', 'html' => 'Cabe exclusivamente ao utilizador avaliar a adequação dos dados ao contexto em que os pretende utilizar.'],
+            ],
+        ],
+        [
+            'title' => '8. Limitação de Responsabilidade',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'O Fogos.pt, os seus responsáveis, colaboradores ou entidades associadas não poderão ser responsabilizados por quaisquer danos diretos, indiretos, incidentais, consequenciais, especiais ou de qualquer outra natureza resultantes da utilização, impossibilidade de utilização ou confiança depositada na informação disponibilizada através da API.'],
+                ['type' => 'p', 'html' => 'Isto inclui, sem limitar, perdas de dados, perdas operacionais, danos reputacionais, falhas de decisão, interrupções de atividade, prejuízos económicos ou quaisquer consequências decorrentes de erros, omissões, indisponibilidade, atrasos ou inexatidões dos dados.'],
+            ],
+        ],
+        [
+            'title' => '9. Utilizações Críticas ou Sensíveis',
+            'blocks' => [
+                ['type' => 'alert_danger', 'html' => 'A API do Fogos.pt não deve ser utilizada como fonte única ou determinante em contextos críticos, de emergência, segurança, proteção civil ou tomada de decisão operacional sensível.'],
+                ['type' => 'p', 'html' => 'A utilização da API em sistemas de alerta, despacho, coordenação operacional, resposta de emergência, proteção de pessoas e bens, ou qualquer outro contexto em que erros, atrasos ou indisponibilidades possam causar danos, deve ser sempre acompanhada de validação independente e de fontes complementares.'],
+                ['type' => 'p', 'html' => 'O utilizador assume integralmente a responsabilidade por qualquer utilização da API em contextos de risco elevado ou decisão crítica.'],
+            ],
+        ],
+        [
+            'title' => '10. Suspensão, Revogação e Bloqueio de Acesso',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'O Fogos.pt reserva-se o direito de, a qualquer momento e sem necessidade de aviso prévio:'],
+                ['type' => 'ul', 'items' => [
+                    ['html' => 'Limitar, suspender ou revogar acessos autorizados'],
+                    ['html' => 'Desativar tokens ou credenciais atribuídas'],
+                    ['html' => 'Bloquear pedidos, origens, aplicações ou utilizadores'],
+                    ['html' => 'Recusar novos pedidos de acesso'],
+                    ['html' => 'Implementar medidas técnicas adicionais de controlo, filtragem ou proteção'],
+                ]],
+                ['type' => 'p', 'html' => 'Estas medidas poderão ser adotadas, nomeadamente, em caso de incumprimento dos presentes termos, utilização abusiva, risco técnico, risco jurídico, impacto negativo no serviço ou necessidade de proteger os utilizadores da plataforma.'],
+            ],
+        ],
+        [
+            'title' => '11. Alterações aos Termos',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'O Fogos.pt poderá alterar os presentes termos de utilização a qualquer momento, sem aviso prévio.'],
+                ['type' => 'p', 'html' => 'É da responsabilidade dos utilizadores consultar periodicamente esta página e assegurar que continuam a cumprir a versão mais atual dos termos aplicáveis.'],
+            ],
+        ],
+        [
+            'title' => '13. Considerações Finais',
+            'blocks' => [
+                ['type' => 'p', 'html' => 'A API do Fogos.pt existe para servir a comunidade e apoiar o acesso a informação de interesse público.'],
+                ['type' => 'p', 'html' => 'A sua utilização deve respeitar o espírito do projeto: <strong>serviço público, responsabilidade, transparência e sustentabilidade</strong>.'],
+                ['type' => 'p', 'html' => 'A continuidade deste serviço depende de uma utilização responsável, identificada e compatível com a missão principal da plataforma: manter o Fogos.pt online, atualizado e estável para todos os cidadãos.'],
+            ],
+        ],
+    ],
+];

--- a/fogospt/resources/views/api-terms.blade.php
+++ b/fogospt/resources/views/api-terms.blade.php
@@ -6,257 +6,54 @@
             <div class="row justify-content-center">
                 <div class="col-lg-10">
 
-                    <h1 class="mb-4">Termos de Utilização da API do Fogos.pt</h1>
+                    <h1 class="mb-4">{{ __('api-terms.title') }}</h1>
 
                     <div class="alert alert-warning">
-                        A utilização da API do Fogos.pt implica a leitura, compreensão e aceitação integral dos presentes termos de utilização.
+                        {{ __('api-terms.intro_alert') }}
                     </div>
 
-                    <div class="mb-4">
-                        <h2>1. Âmbito</h2>
-                        <p>
-                            A API do Fogos.pt é disponibilizada no âmbito de um projeto de interesse público, com o objetivo de promover
-                            o acesso a informação sobre incêndios de forma transparente, aberta e acessível.
-                        </p>
-                        <p>
-                            O Fogos.pt reserva-se o direito de definir regras de acesso, autenticação, controlo técnico e limitação de utilização,
-                            sempre que tal seja necessário para proteger a estabilidade, a disponibilidade e a sustentabilidade da plataforma.
-                        </p>
-                    </div>
-
-                    <hr>
-
-                    <div class="mb-4">
-                        <h2>2. Utilização Permitida</h2>
-                        <p>É permitida a utilização da API nos seguintes contextos:</p>
-
-                        <ul>
-                            <li>
-                                <strong>Utilização pessoal</strong>, incluindo projetos individuais, académicos, educativos, de investigação ou experimentais
-                            </li>
-                            <li>
-                                <strong>Utilização por entidades, incluindo empresas, para fins não comerciais</strong>, nomeadamente:
-                                <ul>
-                                    <li>Investigação</li>
-                                    <li>Análise de dados</li>
-                                    <li>Ferramentas internas de apoio operacional</li>
-                                    <li>Projetos cívicos ou de interesse público</li>
-                                    <li>Monitorização ou visualização interna sem exploração comercial</li>
-                                </ul>
-                            </li>
-                        </ul>
-
-                        <p>
-                            A permissão de utilização depende, quando aplicável, da obtenção de autorização prévia e da atribuição de credenciais de acesso válidas.
-                        </p>
-                    </div>
-
-                    <hr>
-
-                    <div class="mb-4">
-                        <h2>3. Utilização Não Permitida</h2>
-
-                        <div class="alert alert-danger">
-                            Não é permitida a utilização da API em contextos de monetização, promoção comercial ou exploração económica direta ou indireta.
+                    @foreach(__('api-terms.sections') as $section)
+                        <div class="mb-4">
+                            <h2>{{ $section['title'] }}</h2>
+                            @foreach($section['blocks'] as $block)
+                                @switch($block['type'])
+                                    @case('p')
+                                        <p>{!! $block['html'] !!}</p>
+                                        @break
+                                    @case('alert_warning')
+                                        <div class="alert alert-warning">{!! $block['html'] !!}</div>
+                                        @break
+                                    @case('alert_danger')
+                                        <div class="alert alert-danger">{!! $block['html'] !!}</div>
+                                        @break
+                                    @case('alert_light')
+                                        <div class="alert alert-light border">{!! $block['html'] !!}</div>
+                                        @break
+                                    @case('ul')
+                                        <ul>
+                                            @foreach($block['items'] as $item)
+                                                <li>{!! $item['html'] !!}
+                                                    @if(!empty($item['subitems']))
+                                                        <ul>
+                                                            @foreach($item['subitems'] as $sub)
+                                                                <li>{!! $sub !!}</li>
+                                                            @endforeach
+                                                        </ul>
+                                                    @endif
+                                                </li>
+                                            @endforeach
+                                        </ul>
+                                        @break
+                                @endswitch
+                            @endforeach
                         </div>
-
-                        <ul>
-                            <li>
-                                Em plataformas, aplicações, websites ou serviços que incluam:
-                                <ul>
-                                    <li><strong>Publicidade</strong>, incluindo banners, anúncios, patrocínios, monetização programática ou conteúdos patrocinados</li>
-                                    <li><strong>Recolha de donativos, contribuições, crowdfunding ou outras formas de financiamento</strong></li>
-                                </ul>
-                            </li>
-                            <li>Em serviços pagos, por subscrição ou mediante qualquer contrapartida económica</li>
-                            <li>Em produtos ou serviços comercializados a terceiros</li>
-                            <li>Em soluções cujo valor ou modelo de negócio dependa, total ou parcialmente, da disponibilização dos dados da API</li>
-                            <li>Na revenda, redistribuição comercial ou sublicenciamento dos dados obtidos através da API</li>
-                            <li>Em qualquer utilização que possa comprometer a <strong>disponibilidade, desempenho, segurança ou estabilidade</strong> do Fogos.pt</li>
-                            <li>Em qualquer utilização que omita ou procure ocultar a origem dos dados</li>
-                            <li>Em qualquer utilização que contorne mecanismos de autenticação, limitação, autorização ou controlo definidos pelo Fogos.pt</li>
-                        </ul>
-                    </div>
-
-                    <hr>
-
-                    <div class="mb-4">
-                        <h2>4. Créditos e Atribuição</h2>
-
-                        <p>
-                            Toda a utilização da API deve incluir <strong>referência clara, visível e inequívoca à origem dos dados</strong>.
-                        </p>
-
-                        <div class="alert alert-light border">
-                            <strong>Fonte: Fogos.pt</strong>
-                        </div>
-
-                        <p>
-                            Sempre que possível, deverá igualmente ser incluído um link para o site oficial:
-                            <a href="https://fogos.pt" target="_blank" rel="noopener noreferrer">https://fogos.pt</a>
-                        </p>
-
-                        <p>
-                            A atribuição deve estar colocada de forma visível ao utilizador final, junto aos dados, mapas, gráficos, dashboards ou qualquer outro
-                            elemento que utilize informação proveniente da API.
-                        </p>
-
-                        <div class="alert alert-warning">
-                            A ausência de atribuição, a atribuição insuficiente ou a ocultação da origem dos dados constitui incumprimento dos presentes termos.
-                        </div>
-                    </div>
-
-                    <hr>
-
-                    <div class="mb-4">
-                        <h2>5. Regras Técnicas de Utilização</h2>
-
-                        <p>Os utilizadores da API comprometem-se a:</p>
-
-                        <ul>
-                            <li>Utilizar exclusivamente os mecanismos de autenticação fornecidos, incluindo token de acesso quando exigido</li>
-                            <li>Enviar os pedidos com o header de autenticação definido pelo Fogos.pt</li>
-                            <li>Incluir um <strong>User-Agent identificável</strong> e, sempre que possível, específico da aplicação ou serviço em causa</li>
-                            <li>Indicar, sempre que possível, o IP ou origem técnica dos pedidos</li>
-                            <li>Não efetuar pedidos excessivos, massivos, automatizados de forma abusiva ou desnecessária</li>
-                            <li>Respeitar limites de utilização, rate limits, quotas ou outras restrições técnicas que venham a ser definidas</li>
-                            <li>Não tentar contornar bloqueios, restrições, mecanismos de monitorização ou medidas de proteção</li>
-                            <li>Adotar boas práticas técnicas que reduzam o impacto da utilização da API na infraestrutura do Fogos.pt</li>
-                        </ul>
-                    </div>
-
-                    <hr>
-
-                    <div class="mb-4">
-                        <h2>6. Disponibilidade do Serviço</h2>
-
-                        <p>
-                            O Fogos.pt não garante que a API esteja permanentemente disponível, ininterrupta, livre de falhas, completa ou atualizada em todos os momentos.
-                        </p>
-
-                        <p>
-                            O acesso à API poderá ser condicionado, limitado, suspenso ou interrompido, total ou parcialmente, por motivos técnicos, operacionais,
-                            de segurança, manutenção, proteção da infraestrutura, alteração de arquitetura ou gestão de recursos.
-                        </p>
-
-                        <p>
-                            O Fogos.pt poderá ainda alterar endpoints, estruturas de resposta, métodos de autenticação, limites de utilização ou outras condições
-                            técnicas sem necessidade de aviso prévio.
-                        </p>
-                    </div>
-
-                    <hr>
-
-                    <div class="mb-4">
-                        <h2>7. Exatidão e Qualidade dos Dados</h2>
-
-                        <p>
-                            Embora o Fogos.pt procure disponibilizar informação útil, atualizada e fiável, <strong>não é prestada qualquer garantia expressa ou implícita</strong>
-                            quanto à exatidão, integridade, atualidade, consistência, disponibilidade ou adequação dos dados a qualquer finalidade específica.
-                        </p>
-
-                        <p>
-                            Os dados disponibilizados através da API podem depender de fontes externas, processos automáticos, integrações técnicas e fluxos de atualização
-                            que estão sujeitos a falhas, atrasos, omissões, inconsistências ou interrupções.
-                        </p>
-
-                        <p>
-                            Cabe exclusivamente ao utilizador avaliar a adequação dos dados ao contexto em que os pretende utilizar.
-                        </p>
-                    </div>
-
-                    <hr>
-
-                    <div class="mb-4">
-                        <h2>8. Limitação de Responsabilidade</h2>
-
-                        <p>
-                            O Fogos.pt, os seus responsáveis, colaboradores ou entidades associadas não poderão ser responsabilizados por quaisquer danos diretos, indiretos,
-                            incidentais, consequenciais, especiais ou de qualquer outra natureza resultantes da utilização, impossibilidade de utilização ou confiança depositada
-                            na informação disponibilizada através da API.
-                        </p>
-
-                        <p>
-                            Isto inclui, sem limitar, perdas de dados, perdas operacionais, danos reputacionais, falhas de decisão, interrupções de atividade, prejuízos económicos
-                            ou quaisquer consequências decorrentes de erros, omissões, indisponibilidade, atrasos ou inexatidões dos dados.
-                        </p>
-                    </div>
-
-                    <hr>
-
-                    <div class="mb-4">
-                        <h2>9. Utilizações Críticas ou Sensíveis</h2>
-
-                        <div class="alert alert-danger">
-                            A API do Fogos.pt não deve ser utilizada como fonte única ou determinante em contextos críticos, de emergência, segurança, proteção civil ou tomada de decisão operacional sensível.
-                        </div>
-
-                        <p>
-                            A utilização da API em sistemas de alerta, despacho, coordenação operacional, resposta de emergência, proteção de pessoas e bens, ou qualquer outro
-                            contexto em que erros, atrasos ou indisponibilidades possam causar danos, deve ser sempre acompanhada de validação independente e de fontes complementares.
-                        </p>
-
-                        <p>
-                            O utilizador assume integralmente a responsabilidade por qualquer utilização da API em contextos de risco elevado ou decisão crítica.
-                        </p>
-                    </div>
-
-                    <hr>
-
-                    <div class="mb-4">
-                        <h2>10. Suspensão, Revogação e Bloqueio de Acesso</h2>
-
-                        <p>O Fogos.pt reserva-se o direito de, a qualquer momento e sem necessidade de aviso prévio:</p>
-
-                        <ul>
-                            <li>Limitar, suspender ou revogar acessos autorizados</li>
-                            <li>Desativar tokens ou credenciais atribuídas</li>
-                            <li>Bloquear pedidos, origens, aplicações ou utilizadores</li>
-                            <li>Recusar novos pedidos de acesso</li>
-                            <li>Implementar medidas técnicas adicionais de controlo, filtragem ou proteção</li>
-                        </ul>
-
-                        <p>
-                            Estas medidas poderão ser adotadas, nomeadamente, em caso de incumprimento dos presentes termos, utilização abusiva, risco técnico,
-                            risco jurídico, impacto negativo no serviço ou necessidade de proteger os utilizadores da plataforma.
-                        </p>
-                    </div>
-
-                    <hr>
-
-                    <div class="mb-4">
-                        <h2>11. Alterações aos Termos</h2>
-
-                        <p>
-                            O Fogos.pt poderá alterar os presentes termos de utilização a qualquer momento, sem aviso prévio.
-                        </p>
-
-                        <p>
-                            É da responsabilidade dos utilizadores consultar periodicamente esta página e assegurar que continuam a cumprir a versão mais atual dos termos aplicáveis.
-                        </p>
-                    </div>
-
-                    <hr>
-
-                    <div class="mb-4">
-                        <h2>13. Considerações Finais</h2>
-
-                        <p>
-                            A API do Fogos.pt existe para servir a comunidade e apoiar o acesso a informação de interesse público.
-                        </p>
-
-                        <p>
-                            A sua utilização deve respeitar o espírito do projeto:
-                            <strong>serviço público, responsabilidade, transparência e sustentabilidade</strong>.
-                        </p>
-
-                        <p>
-                            A continuidade deste serviço depende de uma utilização responsável, identificada e compatível com a missão principal da plataforma:
-                            manter o Fogos.pt online, atualizado e estável para todos os cidadãos.
-                        </p>
-                    </div>
+                        @if(!$loop->last)
+                            <hr>
+                        @endif
+                    @endforeach
 
                 </div>
             </div>
+        </div>
     </main>
 @endsection

--- a/fogospt/resources/views/api.blade.php
+++ b/fogospt/resources/views/api.blade.php
@@ -9,123 +9,124 @@
                     <div class="col-lg-10">
 
                         <div class="mb-4">
-                            <h1 class="mb-3">Acesso à API do Fogos.pt — Novas Regras e Controlo de Utilização</h1>
+                            <h1 class="mb-3">{{ __('api-docs.title') }}</h1>
                             <p class="lead">
-                                O Fogos.pt tem, ao longo dos anos, disponibilizado uma API pública amplamente utilizada por diversas entidades e projetos.
+                                {{ __('api-docs.intro_lead') }}
                             </p>
                             <p>
-                                Essa abertura foi sempre intencional e alinhada com os princípios do projeto:
-                                <strong>dados abertos, transparência e utilidade pública</strong>.
+                                {{ __('api-docs.intro_p2_before') }}
+                                <strong>{{ __('api-docs.intro_p2_strong') }}</strong>{{ __('api-docs.intro_p2_after') }}
                             </p>
                             <p>
-                                No entanto, o crescimento significativo da utilização da API — muitas vezes sem qualquer identificação ou controlo —
-                                tem vindo a criar desafios ao nível da <strong>performance, estabilidade e disponibilidade</strong>.
+                                {{ __('api-docs.intro_p3_before') }}
+                                <strong>{{ __('api-docs.intro_p3_strong') }}</strong>{{ __('api-docs.intro_p3_after') }}
                             </p>
                             <p>
-                                Foram também identificadas situações de utilização abusiva, que consomem recursos de forma desproporcional.
+                                {{ __('api-docs.intro_p4') }}
                             </p>
                         </div>
 
                         <hr>
 
                         <div class="mb-4">
-                            <h2>Porque é que isto muda agora?</h2>
+                            <h2>{{ __('api-docs.why_title') }}</h2>
                             <p>
-                                O objetivo principal do Fogos.pt mantém-se:
-                                <strong>garantir informação fiável, atualizada e acessível a todos os cidadãos</strong>.
+                                {{ __('api-docs.why_p1_before') }}
+                                <strong>{{ __('api-docs.why_p1_strong') }}</strong>{{ __('api-docs.why_p1_after') }}
                             </p>
                             <p>
-                                Para isso, é essencial assegurar que a infraestrutura não é comprometida por acessos descontrolados.
+                                {{ __('api-docs.why_p2') }}
                             </p>
                             <p>
-                                Estas alterações pretendem garantir que todos conseguem continuar a usar o serviço de forma estável e sustentável.
+                                {{ __('api-docs.why_p3') }}
                             </p>
                         </div>
 
                         <hr>
 
                         <div class="mb-4">
-                            <h2>O que vai mudar?</h2>
+                            <h2>{{ __('api-docs.change_title') }}</h2>
 
                             <div class="alert alert-warning">
-                                <strong>Brevemente</strong>, o acesso à API passará a estar restrito a utilizadores autorizados.
+                                @if(__('api-docs.change_alert_before') !== '')
+                                    {{ __('api-docs.change_alert_before') }}
+                                @endif
+                                <strong>{{ __('api-docs.change_alert_strong') }}</strong>{{ __('api-docs.change_alert_after') }}
                             </div>
 
-                            <p>Todos os pedidos à API deverão cumprir:</p>
+                            <p>{{ __('api-docs.change_intro') }}</p>
 
                             <ul>
                                 <li>
-                                    Autenticação obrigatória via header:
-                                    <pre class="bg-light p-2">FOGOS-PT-AUTH: {token}</pre>
+                                    {{ __('api-docs.req_auth_intro') }}
+                                    <pre class="bg-light p-2">{{ __('api-docs.req_auth_pre') }}</pre>
                                 </li>
-                                <li>Utilização de <strong>token individual</strong></li>
-                                <li>User-Agent <strong>identificável e personalizado</strong></li>
-                                <li>Indicação do <strong>IP de origem</strong>, sempre que possível</li>
+                                <li>{!! __('api-docs.req_token') !!}</li>
+                                <li>{!! __('api-docs.req_user_agent') !!}</li>
+                                <li>{!! __('api-docs.req_ip') !!}</li>
                             </ul>
 
                             <div class="alert alert-danger mt-3">
-                                Pedidos que não cumpram estes requisitos poderão ser limitados ou bloqueados.
+                                {{ __('api-docs.change_danger') }}
                             </div>
                         </div>
 
                         <hr>
 
                         <div class="mb-4">
-                            <h2>Como obter acesso?</h2>
+                            <h2>{{ __('api-docs.access_title') }}</h2>
 
                             <p>
-                                O acesso à API passará a depender de um pedido formal.
+                                {{ __('api-docs.access_p1') }}
                             </p>
 
                             <p>
-                                Para solicitar autorização, deverá preencher o formulário:
+                                {{ __('api-docs.access_p2') }}
                             </p>
 
                             <div class="alert alert-info">
-                                👉 <strong><a href="https://forms.gle/TH1REx1nEm9MnJVM9">Formulário</a></strong>
+                                👉 <strong><a href="{{ __('api-docs.form_url') }}">{{ __('api-docs.form_label') }}</a></strong>
                             </div>
 
-                            <p>Cada pedido será analisado com base em:</p>
+                            <p>{{ __('api-docs.review_intro') }}</p>
 
                             <ul>
-                                <li>Finalidade de utilização</li>
-                                <li>Volume de pedidos</li>
-                                <li>Impacto na infraestrutura</li>
-                                <li>Alinhamento com os objetivos do projeto</li>
+                                @foreach(__('api-docs.review_criteria') as $criterion)
+                                    <li>{{ $criterion }}</li>
+                                @endforeach
                             </ul>
                         </div>
 
                         <hr>
 
                         <div class="mb-4">
-                            <h2>Princípios de utilização</h2>
+                            <h2>{{ __('api-docs.principles_title') }}</h2>
 
                             <ul>
-                                <li>Não comprometer a <strong>disponibilidade do serviço</strong></li>
-                                <li>Evitar cargas excessivas ou desnecessárias</li>
-                                <li>Garantir identificação clara dos pedidos</li>
-                                <li>Utilização responsável e ética dos dados</li>
+                                @foreach(__('api-docs.principles') as $principle)
+                                    <li>{!! $principle !!}</li>
+                                @endforeach
                             </ul>
                         </div>
 
                         <hr>
 
                         <div class="mb-4">
-                            <h2>Um compromisso com a comunidade</h2>
+                            <h2>{{ __('api-docs.community_title') }}</h2>
 
                             <p>
-                                O Fogos.pt continuará a ser um projeto
-                                <strong>aberto, transparente e ao serviço da sociedade</strong>.
+                                {{ __('api-docs.community_p1_before') }}
+                                <strong>{{ __('api-docs.community_p1_strong') }}</strong>{{ __('api-docs.community_p1_after') }}
                             </p>
 
                             <p>
-                                Estas medidas são necessárias para garantir que a plataforma continua a servir
-                                <strong>milhões de utilizadores todos os anos</strong>, especialmente em momentos críticos.
+                                {{ __('api-docs.community_p2_before') }}
+                                <strong>{{ __('api-docs.community_p2_strong') }}</strong>{{ __('api-docs.community_p2_after') }}
                             </p>
 
                             <p>
-                                Contamos com a colaboração de todos para manter este serviço
-                                <strong>fiável, estável e sustentável</strong>.
+                                {{ __('api-docs.community_p3_before') }}
+                                <strong>{{ __('api-docs.community_p3_strong') }}</strong>{{ __('api-docs.community_p3_after') }}
                             </p>
                         </div>
 


### PR DESCRIPTION
Add internationalized content for API documentation and terms: new translation files for English, Spanish and Portuguese (api-docs and api-terms). Update GenericController to use translated meta titles for the API pages. Refactor api-terms.blade.php to render sections and blocks dynamically from the translation arrays, enabling localized content and reducing duplicated markup. Also adjust API view to use translations for the docs page.