### PR TITLE
fix(i18n): localize DataTables strings on the fires table (#111)

### DIFF
--- a/fogospt/resources/lang/en/pages.php
+++ b/fogospt/resources/lang/en/pages.php
@@ -239,6 +239,11 @@ return [
         'reload' => 'This page auto refreshes.'
     ],
     'list' => [
-        'no-data' => 'Sem registo de incêndios'
+        'no-data'       => 'No fire incidents',
+        'search'        => 'Search:',
+        'info'          => 'Showing _TOTAL_ fires',
+        'info-empty'    => 'Showing 0 fires',
+        'info-filtered' => '(filtered from _MAX_ total fires)',
+        'zero-records'  => 'No matching fires found',
     ]
 ];

--- a/fogospt/resources/lang/es/pages.php
+++ b/fogospt/resources/lang/es/pages.php
@@ -244,6 +244,14 @@ return [
     ],
     'table' => [
         'reload' => 'esta página se actualiza automáticamente.'
+    ],
+    'list' => [
+        'no-data'       => 'Sin registro de incendios',
+        'search'        => 'Buscar:',
+        'info'          => 'Mostrando _TOTAL_ incendios',
+        'info-empty'    => 'Mostrando 0 incendios',
+        'info-filtered' => '(filtrado de un total de _MAX_ incendios)',
+        'zero-records'  => 'Ningún incendio encontrado',
     ]
 
 ];

--- a/fogospt/resources/lang/pt/pages.php
+++ b/fogospt/resources/lang/pt/pages.php
@@ -252,7 +252,12 @@ return [
         'reload' => 'Esta página é atualizada automaticamente.'
     ],
     'list' => [
-        'no-data' => 'Sem registo de incêndios'
+        'no-data'       => 'Sem registo de incêndios',
+        'search'        => 'Pesquisar:',
+        'info'          => 'A mostrar _TOTAL_ incêndios',
+        'info-empty'    => 'A mostrar 0 incêndios',
+        'info-filtered' => '(filtrado de um total de _MAX_ incêndios)',
+        'zero-records'  => 'Nenhum incêndio encontrado',
     ]
 
 ];

--- a/fogospt/resources/views/table.blade.php
+++ b/fogospt/resources/views/table.blade.php
@@ -62,7 +62,14 @@
             $('#fires').DataTable({
                 paging: false,
                 stateSave: true,
-                order: [[ 0, 'desc' ]]
+                order: [[ 0, 'desc' ]],
+                language: {
+                    search:       @json(__('pages.list.search')),
+                    info:         @json(__('pages.list.info')),
+                    infoEmpty:    @json(__('pages.list.info-empty')),
+                    infoFiltered: @json(__('pages.list.info-filtered')),
+                    zeroRecords:  @json(__('pages.list.zero-records'))
+                }
             });
 
             setTimeout(function() {


### PR DESCRIPTION
Closes #111.

## Problem

The [`/tabela`](https://fogos.pt/pt/tabela) page initialises DataTables without a `language` option, so DataTables falls back to its built-in **English** strings — `Search:` and `Showing 1 to 14 of 14 entries` — regardless of the selected locale.

## Change

- Add a localized `list` block (`search`, `info`, `info-empty`, `info-filtered`, `zero-records`) to `resources/lang/{pt,en,es}/pages.php`.
- Wire those strings into the DataTable init in `table.blade.php` via `@json(__('pages.list.…'))`, using DataTables' `_TOTAL_` / `_MAX_` placeholders.

While editing the same `list` block I also fixed two adjacent localization gaps:

- `en/pages.php` had `list.no-data` written in **Portuguese** (`Sem registo de incêndios`).
- `es/pages.php` had **no `list` block at all**, so `@lang('pages.list.no-data')` would render the raw key for Spanish visitors.

## Result

| Locale | Search label | Info line |
|---|---|---|
| pt | `Pesquisar:` | `A mostrar 14 incêndios` |
| en | `Search:` | `Showing 14 fires` |
| es | `Buscar:` | `Mostrando 14 incendios` |

When a search filters the table, the info line appends e.g. `(filtrado de um total de 14 incêndios)`.

## Notes

- No build step needed — Blade templates and lang files are resolved at runtime.
- The approach differs slightly from the suggestion in the issue: DataTables 1.10 substitutes its own `_TOTAL_`/`_MAX_` tokens client-side rather than Laravel's `:number` pluralization, so the strings use DataTables placeholders. The end result matches the requested localization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
